### PR TITLE
feat(docs): add `vercel` analytics

### DIFF
--- a/docs/app/.vitepress/theme/index.js
+++ b/docs/app/.vitepress/theme/index.js
@@ -1,9 +1,15 @@
 import DefaultTheme from 'vitepress/theme-without-fonts';
 import SwaggerViewer from './components/SwaggerViewer.vue';
+import { inject } from '@vercel/analytics'
 import "@catppuccin/vitepress/theme/frappe/blue.css";
 import "./custom.css";
 import "./swagger.css";
 import "./custom-fonts.css";
+
+// Inject Vercel Analytics only in production and on the client-side
+if (process.env.NODE_ENV === 'production' && typeof window !== 'undefined') {
+    inject();
+  }
 
 export default {
   extends: DefaultTheme,

--- a/docs/app/package-lock.json
+++ b/docs/app/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@catppuccin/vitepress": "^0.1.0",
         "@ibm/plex": "^6.4.1",
+        "@vercel/analytics": "^1.5.0",
         "swagger-ui": "^5.20.8",
         "vitepress-openapi": "^0.0.3-alpha.72"
       }
@@ -1957,6 +1958,44 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.3",

--- a/docs/app/package.json
+++ b/docs/app/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@catppuccin/vitepress": "^0.1.0",
     "@ibm/plex": "^6.4.1",
+    "@vercel/analytics": "^1.5.0",
     "swagger-ui": "^5.20.8",
     "vitepress-openapi": "^0.0.3-alpha.72"
   }


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

Add vercel analytics to vitepress docs.

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Add Vercel Analytics to the VitePress documentation site for tracking and insights

New Features:
- Integrate Vercel Analytics to track usage and performance of the documentation site

Enhancements:
- Add client-side analytics injection with environment-specific conditions

Documentation:
- Configure Vercel Analytics to run only in production environment