### PR TITLE
fix: default filter for task state

### DIFF
--- a/poiesis/api/api_handlers.py
+++ b/poiesis/api/api_handlers.py
@@ -64,7 +64,7 @@ async def GetServiceInfo() -> TesServiceInfo:
 @pydantic_to_dict_response
 async def ListTasks(  # noqa: PLR0913
     name_prefix: str | None = None,
-    state: str | None = TesState.UNKNOWN.value,
+    state: str | None = None,
     tag_key: list[str] | None = None,
     tag_value: list[str] | None = None,
     page_size: int | None = None,

--- a/poiesis/api/tes/spec/c4c17c9.openapi.yaml
+++ b/poiesis/api/tes/spec/c4c17c9.openapi.yaml
@@ -810,7 +810,6 @@ components:
          - `PREEMPTED`: The task is stopped (preempted) by the system. The reasons for this would be tied to
         the specific system running the job. Generally, this means that the system reclaimed the compute
         capacity for reallocation.
-      default: UNKNOWN
       example: COMPLETE
       enum:
         - UNKNOWN

--- a/poiesis/api/tes/spec/c4c17c9.openapi.yaml
+++ b/poiesis/api/tes/spec/c4c17c9.openapi.yaml
@@ -5,6 +5,7 @@
 # - Removed the `BasicAuth`, the API is secured with Bearer token
 # - Added `x-bearerInfoFunc` to the BearerAuth security scheme
 # - Formatted the file with yamllint
+# - Removed default state parameter from filter which was wrongly set to UNKNOWN
 openapi: 3.0.1
 info:
   title: Task Execution Service


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

There should be no default filter for task state as metioned in the specs

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Remove the unintended default task state filter from the ListTasks endpoint in both code and spec

Bug Fixes:
- Remove default UNKNOWN state value from the ListTasks API handler so tasks aren’t filtered by state by default
- Remove the default 'UNKNOWN' entry from the OpenAPI spec for the task state parameter