### PR TITLE
fix: filter by tags

### DIFF
--- a/poiesis/api/controllers/list_tasks.py
+++ b/poiesis/api/controllers/list_tasks.py
@@ -65,18 +65,21 @@ class ListTasksController(InterfaceController):
 
         # Tags
         if self.query_filter.tag_key:
-            for key, val in zip(
-                self.query_filter.tag_key,
-                self.query_filter.tag_value or [],
-                strict=False,
-            ):
-                if val == "":
+            for i, key in enumerate(self.query_filter.tag_key or []):
+                val = None
+                if self.query_filter.tag_value and i < len(self.query_filter.tag_value):
+                    val = self.query_filter.tag_value[i]
+
+                if val is None or val == "":
                     tag_filter.append({f"tags.{key}": {"$exists": True}})
                 else:
                     tag_filter.append({f"tags.{key}": val})
 
         if tag_filter:
-            query["$and"] = tag_filter
+            if "$and" in query:
+                query["$and"].extend(tag_filter)
+            else:
+                query["$and"] = tag_filter
 
         if self.user_id:
             query["user_id"] = self.user_id


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

The prev implementation would work in MongoDB if all these tag keys exist and match. But misses the below edge case:

- If `tag_key` has more items than `tag_value`, `zip(..., strict=False)` will ignore extra keys silently.

- If we want to allow filtering by "tag key exists" (e.g., tag_value is missing or empty), we're relying on the $exists operator — that’s correct, but some test may not be sending empty strings as we expect.

- Some tags might be optional or not present in the document, leading to no matches when `$and` is too strict.

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Fix tag-based filtering by handling missing or empty tag values correctly and by merging new conditions with existing filters.

Bug Fixes:
- Correct tag filter to process tag keys without corresponding values and treat empty or missing values as existence checks.
- Append tag filter conditions to existing `$and` query clauses instead of overwriting them.