### PR TITLE
fix: invalidate `backend_parameters`

### DIFF
--- a/poiesis/api/api_handlers.py
+++ b/poiesis/api/api_handlers.py
@@ -122,6 +122,8 @@ async def CreateTask(body: dict[str, Any]) -> TesCreateTaskResponse:
             message="Invalid request body",
             details=e.errors(),
         ) from e
+    if task.resources and task.resources.backend_parameters_strict:
+        raise BadRequestException("Backend parameters are not valid.")
     controller = CreateTaskController(db=db, task=task, user_id=user_id)
     return await controller.execute()
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #(issue number)

Poiesis currently only supports one backend, in such case backend parameter don't make sense just for Kubernetes, all other kubernetes related configs are already set by other TES response fields.

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Bug Fixes:
- Raise BadRequestException if backend_parameters_strict is set in task resources