### PR TITLE
chore: enable multi-arch docker and update docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ NAME := poiesis
 VERSION := $(shell uv tree | grep ${NAME} | awk '{print $$2}' | sed 's/^v//')
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 GIT_REVISION := $(shell git rev-parse HEAD)
-PY_VERSION := $(shell uvx python --version | awk '{print$$2}')
+PY_VERSION := 3.13.0
 DOCKERFILE := deployment/images/Dockerfile
 
 # Full image names
@@ -137,6 +137,7 @@ PHONY: build-docker-image bi
 build-docker-image:
 	@echo "\nBuilding Docker image +++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n"
 	@docker build \
+		--platform linux/amd64,linux/arm64 \
 		--build-arg PY_VERSION="${PY_VERSION}" \
 		--build-arg BUILD_DATE="${BUILD_DATE}" \
 		--build-arg GIT_REVISION="${GIT_REVISION}" \

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A [TES] compliant task execution service built on kubernetes with `security`,
 ## Installation
 
 > **Note:** This is a high-level overview. For detailed instructions, please
-> refer to the [Deployment Docs](https://poiesis.readthedocs.io/en/docs/).
+> refer to the [Deployment Docs](https://poiesis.vercel.app/docs/deploy/deploying-poiesis.html).
 
 To install Poiesis into your Kubernetes cluster using Helm:
 


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #(issue number)

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Pin Python version to 3.13.0, enable multi-architecture Docker builds, and update the deployment documentation link in the README.

Enhancements:
- Pin the Makefile’s PY_VERSION variable to 3.13.0 instead of detecting it dynamically
- Enable building Docker images for linux/amd64 and linux/arm64 platforms

Documentation:
- Update the README’s Deployment Docs link to the new Vercel-hosted URL