### PR TITLE
fix: remove cluster roles and move job permissions

### DIFF
--- a/deployment/dev.yaml
+++ b/deployment/dev.yaml
@@ -16,35 +16,6 @@ metadata:
   namespace: po
 ...
 ---
-# CLUSTER ROLE: For permissions across the entire cluster (e.g., creating jobs)
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: poiesis-cluster-role
-rules:
-  - apiGroups: ["batch"]
-    resources: ["jobs"]
-    verbs: ["create", "get", "list", "watch", "delete"]
-  - apiGroups: [""]
-    resources: ["nodes", "persistentvolumes"]
-    verbs: ["get", "list", "watch"]
-...
----
-# CLUSTER ROLE BINDING: Binds the ClusterRole to our ServiceAccount
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: poiesis-cluster-role-binding
-subjects:
-  - kind: ServiceAccount
-    name: poiesis-sa
-    namespace: po
-roleRef:
-  kind: ClusterRole
-  name: poiesis-cluster-role
-  apiGroup: rbac.authorization.k8s.io
-...
----
 # ROLE: For permissions ONLY within the 'po' namespace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -56,6 +27,9 @@ rules:
     resources:
       ["pods", "pods/log", "persistentvolumeclaims", "secrets", "configmaps"]
     verbs: ["create", "get", "list", "watch", "delete", "patch", "update"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
 ...
 ---
 # ROLE BINDING: Binds the namespaced Role to our ServiceAccount

--- a/deployment/helm/templates/_helper.tpl
+++ b/deployment/helm/templates/_helper.tpl
@@ -84,7 +84,7 @@ rbac.authorization.k8s.io/v1beta1
 {{- end }}
 
 {{/*
-Namespaced RBAC rules (exclude cluster-scoped resources like Jobs)
+Namespaced RBAC rules (include Jobs - they are namespace-scoped, not cluster-scoped)
 */}}
 {{- define "poiesis.rbac.namespacedRules" }}
 {{- $namespacedRules := list
@@ -94,21 +94,14 @@ Namespaced RBAC rules (exclude cluster-scoped resources like Jobs)
     (dict "apiGroups" (list "")
         "resources" (list "pods/log")
         "verbs" (list "get"))
+    (dict "apiGroups" (list "batch")
+        "resources" (list "jobs")
+        "verbs" (list "create" "get" "list" "watch" "delete"))
 }}
 {{ toYaml $namespacedRules | indent 2 }}
 {{- end }}
 
-{{/*
-Cluster-scoped RBAC rules (include Jobs)
-*/}}
-{{- define "poiesis.rbac.clusterRules" }}
-{{- $clusterRules := list
-  (dict "apiGroups" (list "batch")
-        "resources" (list "jobs")
-        "verbs" (list "create" "get" "list" "watch" "delete"))
-}}
-{{ toYaml $clusterRules | indent 2 }}
-{{- end }}
+
 
 {{/*
 Common annotations block

--- a/deployment/helm/templates/poiesis/rbac.yaml
+++ b/deployment/helm/templates/poiesis/rbac.yaml
@@ -42,37 +42,3 @@ roleRef:
   kind: Role
   name: {{ include "poiesis.serviceAccountName" . }}-role
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: {{ include "poiesis.rbac.apiVersion" . }}
-kind: ClusterRole
-metadata:
-  name: {{ include "poiesis.serviceAccountName" . }}-clusterrole
-  labels:
-    {{- include "poiesis.labels" . | nindent 4 }}
-    app.kubernetes.io/component: rbac
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-rules:
-  {{- include "poiesis.rbac.clusterRules" . | indent 2 }}
----
-apiVersion: {{ include "poiesis.rbac.apiVersion" . }}
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "poiesis.serviceAccountName" . }}-clusterbinding
-  labels:
-    {{- include "poiesis.labels" . | nindent 4 }}
-    app.kubernetes.io/component: rbac
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-subjects:
-- kind: ServiceAccount
-  name: {{ include "poiesis.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: {{ include "poiesis.serviceAccountName" . }}-clusterrole
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #54 

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Remove cluster-scoped RBAC definitions and consolidate permissions into a single namespaced Role including job support.

Bug Fixes:
- Remove ClusterRole and ClusterRoleBinding resources from Helm templates and development manifests

Enhancements:
- Add batch/jobs permissions to the namespaced Role
- Update Helm RBAC helper to consolidate all rules under namespacedRules and drop separate clusterRules