### PR TITLE
fix: pass `PVC` access mode and storage class

### DIFF
--- a/deployment/helm/templates/poiesis/deployment.yaml
+++ b/deployment/helm/templates/poiesis/deployment.yaml
@@ -53,6 +53,10 @@ spec:
               value: {{ .Values.poiesis.service.port | quote}}
             - name: MONGODB_MAX_POOL_SIZE
               value: {{ .Values.poiesis.config.mongodbMaxPoolSize | quote }}
+            - name: POIESIS_PVC_ACCESS_MODE
+              value: {{ .Values.poiesis.storage.accessMode | quote }}
+            - name: POIESIS_PVC_STORAGE_CLASS
+              value: {{ .Values.poiesis.storage.className | quote }}
             - name: POIESIS_SERVICE_ACCOUNT_NAME
               value: {{ include "poiesis.serviceAccountName" . }}
             - name: MONGODB_DATABASE

--- a/poiesis/api/controllers/create_task.py
+++ b/poiesis/api/controllers/create_task.py
@@ -172,6 +172,14 @@ class CreateTaskController(InterfaceController):
                                             )
                                         ),
                                     ),
+                                    V1EnvVar(
+                                        name="POIESIS_PVC_ACCESS_MODE",
+                                        value=core_constants.K8s.PVC_ACCESS_MODE,
+                                    ),
+                                    V1EnvVar(
+                                        name="POIESIS_PVC_STORAGE_CLASS",
+                                        value=core_constants.K8s.PVC_STORAGE_CLASS,
+                                    ),
                                 ],
                                 image_pull_policy=core_constants.K8s.IMAGE_PULL_POLICY,
                             ),

--- a/poiesis/core/constants.py
+++ b/poiesis/core/constants.py
@@ -70,8 +70,8 @@ class PoiesisCoreConstants:
         PVC_PREFIX = "pvc"
         TEXAM_PREFIX = "texam"
         PVC_DEFAULT_DISK_SIZE = "1Gi"
-        PVC_ACCESS_MODE = os.getenv("POIESIS_PVC_ACCESS_MODE", "ReadWriteOnce")
-        PVC_STORAGE_CLASS = os.getenv("POIESIS_PVC_STORAGE_CLASS", "standard")
+        PVC_ACCESS_MODE = os.getenv("POIESIS_PVC_ACCESS_MODE")
+        PVC_STORAGE_CLASS = os.getenv("POIESIS_PVC_STORAGE_CLASS")
         POIESIS_IMAGE = os.getenv("POIESIS_IMAGE", "docker.io/jaeaeich/poiesis:latest")
         COMMON_PVC_VOLUME_NAME = "task-pvc-volume"
         FILER_PVC_PATH = "/transfer"

--- a/poiesis/core/services/torc/torc.py
+++ b/poiesis/core/services/torc/torc.py
@@ -10,6 +10,7 @@ from kubernetes.client import (
     V1ResourceRequirements,
 )
 
+from poiesis.api.exceptions import InternalServerException
 from poiesis.api.tes.models import (
     TesInput,
     TesOutput,
@@ -145,6 +146,12 @@ class Torc:
             f"PVC storage size: {size}Gi if size else "
             f"{core_constants.K8s.PVC_DEFAULT_DISK_SIZE}"
         )
+
+        if not core_constants.K8s.PVC_ACCESS_MODE:
+            raise InternalServerException(
+                message="PVC access mode is not set.",
+                details="PVC access mode is not set.",
+            )
 
         pvc = V1PersistentVolumeClaim(
             api_version="v1",

--- a/poiesis/core/services/torc/torc.py
+++ b/poiesis/core/services/torc/torc.py
@@ -10,7 +10,6 @@ from kubernetes.client import (
     V1ResourceRequirements,
 )
 
-from poiesis.api.exceptions import InternalServerException
 from poiesis.api.tes.models import (
     TesInput,
     TesOutput,
@@ -147,11 +146,15 @@ class Torc:
             f"{core_constants.K8s.PVC_DEFAULT_DISK_SIZE}"
         )
 
-        if not core_constants.K8s.PVC_ACCESS_MODE:
-            raise InternalServerException(
-                message="PVC access mode is not set.",
-                details="PVC access mode is not set.",
+        if (
+            not core_constants.K8s.PVC_ACCESS_MODE
+            and not core_constants.K8s.PVC_STORAGE_CLASS
+        ):
+            logger.warning(
+                "PVC access mode and storage class are not set. Using default values."
             )
+            logger.debug(f"PVC access mode: {core_constants.K8s.PVC_ACCESS_MODE}")
+            logger.debug(f"PVC storage class: {core_constants.K8s.PVC_STORAGE_CLASS}")
 
         pvc = V1PersistentVolumeClaim(
             api_version="v1",
@@ -165,8 +168,10 @@ class Torc:
                 },
             ),
             spec=V1PersistentVolumeClaimSpec(
-                access_modes=[core_constants.K8s.PVC_ACCESS_MODE],
-                storage_class_name=core_constants.K8s.PVC_STORAGE_CLASS,
+                access_modes=[core_constants.K8s.PVC_ACCESS_MODE]
+                if core_constants.K8s.PVC_ACCESS_MODE
+                else None,
+                storage_class_name=core_constants.K8s.PVC_STORAGE_CLASS or None,
                 resources=V1ResourceRequirements(
                     requests={
                         "storage": f"{size}Gi"


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #57
<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Ensure PVC access mode and storage class are sourced from configuration, passed into Torc job containers, and validated to fix missing PVC settings.

Bug Fixes:
- Pass POIESIS_PVC_ACCESS_MODE and POIESIS_PVC_STORAGE_CLASS environment variables to the Torc job container.

Enhancements:
- Expose PVC access mode and storage class as Helm chart values and map them to container environment variables.
- Remove default PVC settings in constants and add a runtime check to error when access mode is unset.