### PR TITLE
feat(helm): set infinite monitor timeout

### DIFF
--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -42,6 +42,7 @@ dependencies:
   - name: redis
     version: 21.0.2
     repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
   - name: mongodb
     version: 16.5.6
     repository: https://charts.bitnami.com/bitnami

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -63,8 +63,13 @@ poiesis:
     # are automatically cleaned up, allowing PVCs to terminate properly.
     # Value in seconds (3600 = 1 hour). Lower values = faster cleanup but less debugging time.
     jobTtl: "3600"
-    # Timeout duration in seconds for monitoring operations.
-    monitorTimeoutSeconds: "80"
+    # Maximum duration (in seconds) allowed for monitoring operations by TExAM.
+    # Also acts as the timeout for executor pods — if any executor
+    # remains active beyond this period (including execution time), it will
+    # be terminated and the associated task marked as failed.
+    # Set to "0" for no timeout (infinite duration).
+    # For example, "10" means 10 seconds.
+    monitorTimeoutSeconds: "0"
 
   # Storage configuration for PVCs used by Poiesis tasks
   # NOTE: PVCs are automatically created for each task and cleaned up when the task completes.


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #(issue number)

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Update Helm chart configuration documentation and add conditional Redis dependency

Enhancements:
- Clarify monitorTimeoutSeconds semantics and set its default value to "0" for infinite timeout

Chores:
- Add `condition: redis.enabled` to the Redis dependency in Chart.yaml