### PR TITLE
fix(texam): run executors sequentially as jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,16 +136,16 @@ v: venv
 PHONY: build-docker-image bi
 build-docker-image:
 	@echo "\nBuilding Docker image +++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n"
-	@docker build \
+	@docker buildx build  \
 		--platform linux/amd64,linux/arm64 \
 		--build-arg PY_VERSION="${PY_VERSION}" \
 		--build-arg BUILD_DATE="${BUILD_DATE}" \
 		--build-arg GIT_REVISION="${GIT_REVISION}" \
 		--build-arg VERSION="${VERSION}" \
-		-t ${IMAGE_TAG_VERSION} \
-		-t ${IMAGE_TAG_LATEST} \
-		-f ${DOCKERFILE} .
-	@echo "\nDocker image built successfully: jaeaeich/poiesis:latest\n"
+		-t jaeaeich/poiesis:alpha23 \
+		-f ${DOCKERFILE} \
+		--push .
+	@echo "\nDocker image built successfully: jaeaeich/poiesis:alpha23\n"
 
 bi: build-docker-image
 

--- a/Makefile
+++ b/Makefile
@@ -136,16 +136,16 @@ v: venv
 PHONY: build-docker-image bi
 build-docker-image:
 	@echo "\nBuilding Docker image +++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n"
-	@docker buildx build  \
+	@docker build \
 		--platform linux/amd64,linux/arm64 \
 		--build-arg PY_VERSION="${PY_VERSION}" \
 		--build-arg BUILD_DATE="${BUILD_DATE}" \
 		--build-arg GIT_REVISION="${GIT_REVISION}" \
 		--build-arg VERSION="${VERSION}" \
-		-t jaeaeich/poiesis:alpha23 \
-		-f ${DOCKERFILE} \
-		--push .
-	@echo "\nDocker image built successfully: jaeaeich/poiesis:alpha23\n"
+		-t ${IMAGE_TAG_VERSION} \
+		-t ${IMAGE_TAG_LATEST} \
+		-f ${DOCKERFILE} .
+	@echo "\nDocker image built successfully: jaeaeich/poiesis:latest\n"
 
 bi: build-docker-image
 

--- a/deployment/helm/Chart.lock
+++ b/deployment/helm/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
   version: 16.5.6
-digest: sha256:0ea98b27e0be5d5c4e7e4ba6bfc9a2ea50f8d301dcad3a4502d93e47559b3178
-generated: "2025-06-17T22:27:05.428794+05:30"
+digest: sha256:cbc5e35c9d96e423836a4e993111f9377563dfaaaef9e9553c62bbcc9684e768
+generated: "2025-07-03T23:10:37.368071+05:30"

--- a/poiesis/core/services/texam/texam.py
+++ b/poiesis/core/services/texam/texam.py
@@ -1,7 +1,6 @@
 """TExAM (Task Executor and Monitor) service."""
 
 import asyncio
-import contextlib
 import logging
 import os
 import shlex
@@ -11,10 +10,12 @@ from kubernetes import watch  # type: ignore
 from kubernetes.client import (
     V1Container,
     V1EnvVar,
+    V1Job,
+    V1JobSpec,
     V1ObjectMeta,
     V1PersistentVolumeClaimVolumeSource,
-    V1Pod,
     V1PodSpec,
+    V1PodTemplateSpec,
     V1ResourceRequirements,
     V1Volume,
     V1VolumeMount,
@@ -40,34 +41,19 @@ core_constants = get_poiesis_core_constants()
 logger = logging.getLogger(__name__)
 
 
-# Note: In future, add any other reasons consider fatal startup errors
-CRITICAL_WAITING_REASONS = {
-    "ImagePullBackOff",
-    "ErrImagePull",
-    "CrashLoopBackOff",
-    "InvalidImageName",
-    "ImageInspectError",
-}
-
-
 class Texam:
     """TExAM service.
 
     Args:
-        name: Name of the task.
-        executors: List of executors.
-        resources: Resources for the executors.
-        volumes: List of volumes to be mounted to the executors.
+        task: TesTask object.
 
     Attributes:
-        name: Name of the task.
-        executors: List of executors.
-        resources: Resources for the executors.
-        volumes: List of volumes to be mounted to the executors.
-        task_pool: List of executors.
+        task: TesTask object.
+        task_id: Task ID.
         kubernetes_client: Kubernetes client.
         message_broker: Message broker.
         failed: Flag defining if TE failed.
+        db: MongoDB client.
     """
 
     def __init__(
@@ -78,34 +64,68 @@ class Texam:
 
         Args:
             task: TesTask object.
-
-        Attributes:
-            task: TesTask object.
-            name: Name of the task.
-            executors: List of executors.
-            resources: Resources for the executors.
-            volumes: List of volumes to be mounted to the executors.
-            task_pool: List of executors pod name and then they were created.
-            kubernetes_client: Kubernetes client.
-            message_broker: Message broker.
-            failed: Flag defining if TE failed.
         """
         self.task = task
         self.task_id = task.id
-        self.task_pool: list[str] = []
         self.kubernetes_client = KubernetesAdapter()
         self.message_broker = RedisMessageBroker()
         self.failed = False
         self.db = MongoDBClient()
-        self.pods_to_cleanup: list[str] = []
 
     async def execute(self) -> None:
-        """Complete TExAM job."""
-        await self.start_executors()
-        self.pods_to_cleanup = self.task_pool.copy()
-        await self.monitor_executors()
-        await self.cleanup_pods()
+        """Execute TExAM.
+
+        Creates individual k8s Jobs for each executor sequentially.
+        If any executor fails, remaining executors are marked as failed.
+        """
+        for idx, executor in enumerate(self.task.executors):
+            if self.failed:
+                # If previous executor failed, mark remaining executors as failed
+                executor_name = f"{core_constants.K8s.TE_PREFIX}-{self.task_id}-{idx}"
+                if self.task_id is not None:
+                    await self.db.add_task_executor_log(self.task_id)
+                await self.db.update_executor_log(
+                    executor_name,
+                    PodPhase.FAILED.value,
+                    stdout=None,
+                    stderr=f"Executor {idx} failed to start because previous executor failed.",
+                )
+                continue
+
+            # Create and monitor executor sequentially
+            success = await self.run_single_executor(executor, idx)
+            if not success:
+                self.failed = True
+                # Mark remaining executors as failed
+                for remaining_idx in range(idx + 1, len(self.task.executors)):
+                    remaining_executor_name = (
+                        f"{core_constants.K8s.TE_PREFIX}-{self.task_id}-{remaining_idx}"
+                    )
+                    if self.task_id is not None:
+                        await self.db.add_task_executor_log(self.task_id)
+                    await self.db.update_executor_log(
+                        remaining_executor_name,
+                        PodPhase.FAILED.value,
+                        stdout=None,
+                        stderr=f"Executor {remaining_idx} failed to start because executor {idx} failed.",
+                    )
+                break
+
         await self.message()
+
+    async def run_single_executor(self, executor: TesExecutor, idx: int) -> bool:
+        """Run a single executor and monitor it to completion.
+
+        Args:
+            executor: Executor object.
+            idx: Index of the executor.
+
+        Returns:
+            True if executor completed successfully, False otherwise.
+        """
+        # Create the executor job
+        job_created = await self.create_executor_job(executor, idx)
+        return await self.monitor_executor_job(executor, idx) if job_created else False
 
     def _build_command_string(self, executor: TesExecutor) -> str:
         """Constructs a shell command string.
@@ -137,385 +157,278 @@ class Texam:
 
         return command_str
 
-    async def start_executors(self) -> None:
-        """Create the K8s job for Texam.
+    async def create_executor_job(self, executor: TesExecutor, idx: int) -> bool:
+        """Create a k8s Job for the executor.
 
-        Try to create all the pods for the executors, if the pod creation
-        fails, gracefully retry with exponential backoff till a certain
-        threshold, failing executors will be ignored and logged.
+        Args:
+            executor: Executor object.
+            idx: Index of the executor.
 
-        Note:
-            Parallelism can be achieved by using threads, but due to kubernetes
-            limit on number of request per second and in the interest of scalability
-            we are launching executors sequentially.
+        Returns:
+            True if job was created successfully, False otherwise.
         """
-        for idx, executor in enumerate(self.task.executors):
-            executor_name = f"{core_constants.K8s.TE_PREFIX}-{self.task_id}-{idx}"
+        executor_name = f"{core_constants.K8s.TE_PREFIX}-{self.task_id}-{idx}"
 
-            async def create_pod_with_backoff(pod_manifest, executor_name):
-                backoff_time = 1
-                while backoff_time <= core_constants.Texam.BACKOFF_LIMIT:
-                    try:
-                        if self.task_id is None:
-                            raise ValueError("Task ID is None")
-                        await self.db.add_task_executor_log(self.task_id)
-                        logger.debug(pod_manifest)
-                        pod_name = await self.kubernetes_client.create_pod(pod_manifest)
-                        self.task_pool.append(pod_name)
-                        break
-                    except Exception as e:
-                        # Cleans the previous pod if it exists, this is to avoid
-                        #   the conflict with the same pod name, so we can try again
-                        #   with the same pod name. Trying to keep the idx same so logs
-                        #   can be associated with the same executor.
-                        logger.error(f"Failed to create pod {executor_name}: {e}")
-                        logger.info(f"Deleting pod {executor_name}")
-                        await self.kubernetes_client.delete_pod(executor_name)
-                        logger.info(f"Retrying in {backoff_time} seconds")
-                        await asyncio.sleep(backoff_time)
-                        backoff_time = min(
-                            backoff_time * 2, core_constants.Texam.BACKOFF_LIMIT
-                        )
-                else:
-                    # After all retries failed, add the executor to task_pool with a
-                    # special status This ensures it will be monitored and properly
-                    # logged
-                    self.task_pool.append(executor_name)
-                    await self.db.update_executor_log(
-                        executor_name,
-                        PodPhase.FAILED.value,
-                        stdout=None,
-                        stderr="Failed to create executor pod after multiple retries.",
+        async def create_job_with_backoff(job_manifest, executor_name) -> bool:
+            backoff_time = 1
+            while backoff_time <= core_constants.Texam.BACKOFF_LIMIT:
+                try:
+                    if self.task_id is None:
+                        raise ValueError("Task ID is None")
+                    await self.db.add_task_executor_log(self.task_id)
+                    logger.debug(f"Creating job for {executor_name}: {job_manifest}")
+                    await self.kubernetes_client.create_job(job_manifest)
+                    return True
+                except Exception as e:
+                    # Clean up the previous job if it exists
+                    logger.error(f"Failed to create job {executor_name}: {e}")
+                    logger.info(f"Deleting job {executor_name}")
+                    await self.kubernetes_client.delete_job(executor_name)
+                    logger.info(f"Retrying in {backoff_time} seconds")
+                    await asyncio.sleep(backoff_time)
+                    backoff_time = min(
+                        backoff_time * 2, core_constants.Texam.BACKOFF_LIMIT
                     )
-                    logger.error(
-                        f"Pod {executor_name} failed to be created after all retries"
-                    )
-
-            _resource = (
-                {
-                    "cpu": str(self.task.resources.cpu_cores)
-                    if self.task.resources.cpu_cores
-                    else None,
-                    "memory": f"{self.task.resources.ram_gb}Gi"
-                    if self.task.resources.ram_gb
-                    else None,
-                }
-                if self.task.resources
-                else {}
+            # After all retries failed, log the failure
+            await self.db.update_executor_log(
+                executor_name,
+                PodPhase.FAILED.value,
+                stdout=None,
+                stderr="Failed to create executor job after multiple retries.",
             )
-            resource = (
-                {k: v for k, v in _resource.items() if v is not None}
-                if _resource
-                else {}
+            logger.error(
+                f"Job {executor_name} failed to be created after all retries"
             )
+            return False
 
-            _parent = f"{core_constants.K8s.TEXAM_PREFIX}-{self.task_id}"
+        _resource = (
+            {
+                "cpu": str(self.task.resources.cpu_cores)
+                if self.task.resources.cpu_cores
+                else None,
+                "memory": f"{self.task.resources.ram_gb}Gi"
+                if self.task.resources.ram_gb
+                else None,
+            }
+            if self.task.resources
+            else {}
+        )
+        resource = (
+            {k: v for k, v in _resource.items() if v is not None} if _resource else {}
+        )
 
-            # Note: Here we create mount paths for each input, since the PVC
-            #   all the data in downloaded in PVC at
-            #   `/transfer/{split_path_for_mounting(input.path)[1]}` directory.
-            #   So we need to mount the PVC at
-            #   `/transfer/{split_path_for_mounting(input.path)[0]}` directory.
-            #   This way the executor can access the data from PVC at the correct
-            #   location, that will be `{split_path_for_mounting(input.path)[1]}/
-            #   {split_path_for_mounting(input.path)[2]}` directory.
-            _volume_pvc_mount = []
-            for input in self.task.inputs or []:
-                _mount_path = split_path_for_mounting(input.path)[0].rstrip("/")
-                _volume_mount = V1VolumeMount(
-                    name=core_constants.K8s.COMMON_PVC_VOLUME_NAME,
-                    mount_path=_mount_path,
-                )
-                # Check if the volume mount is already in the list else
-                #   K8s won't process and throw 422 error.
-                if input.path and _volume_mount not in _volume_pvc_mount:
-                    _volume_pvc_mount.append(_volume_mount)
+        _parent = f"{core_constants.K8s.TEXAM_PREFIX}-{self.task_id}"
 
-            pod_manifest = V1Pod(
-                api_version="v1",
-                kind="Pod",
-                metadata=V1ObjectMeta(
-                    name=executor_name,
-                    labels={
-                        "service": core_constants.K8s.TE_PREFIX,
-                        "parent": _parent,
-                        "name": executor_name,
-                    },
-                ),
-                spec=V1PodSpec(
-                    security_context=get_executor_pod_security_context(),
-                    containers=[
-                        V1Container(
-                            name=executor_name,
-                            image=executor.image,
-                            command=["/bin/sh", "-c"],
-                            args=[self._build_command_string(executor)],
-                            working_dir=executor.workdir,
-                            env=[
-                                V1EnvVar(name=key, value=value)
-                                for key, value in executor.env.items()
-                            ]
-                            if executor.env is not None
-                            else [],
-                            resources=V1ResourceRequirements(
-                                limits=resource,
-                                requests=resource,
+        # Note: Here we create mount paths for each input, since the PVC
+        #   all the data in downloaded in PVC at
+        #   `/transfer/{split_path_for_mounting(input.path)[1]}` directory.
+        #   So we need to mount the PVC at
+        #   `/transfer/{split_path_for_mounting(input.path)[0]}` directory.
+        #   This way the executor can access the data from PVC at the correct
+        #   location, that will be `{split_path_for_mounting(input.path)[1]}/
+        #   {split_path_for_mounting(input.path)[2]}` directory.
+        _volume_pvc_mount = []
+        for input in self.task.inputs or []:
+            _mount_path = split_path_for_mounting(input.path)[0].rstrip("/")
+            _volume_mount = V1VolumeMount(
+                name=core_constants.K8s.COMMON_PVC_VOLUME_NAME,
+                mount_path=_mount_path,
+            )
+            # Check if the volume mount is already in the list else
+            #   K8s won't process and throw 422 error.
+            if input.path and _volume_mount not in _volume_pvc_mount:
+                _volume_pvc_mount.append(_volume_mount)
+
+        job_manifest = V1Job(
+            api_version="batch/v1",
+            kind="Job",
+            metadata=V1ObjectMeta(
+                name=executor_name,
+                labels={
+                    "service": core_constants.K8s.TE_PREFIX,
+                    "parent": _parent,
+                    "name": executor_name,
+                },
+            ),
+            spec=V1JobSpec(
+                ttl_seconds_after_finished=int(core_constants.K8s.JOB_TTL)
+                if core_constants.K8s.JOB_TTL
+                else None,
+                template=V1PodTemplateSpec(
+                    metadata=V1ObjectMeta(
+                        labels={
+                            "service": core_constants.K8s.TE_PREFIX,
+                            "parent": _parent,
+                            "name": executor_name,
+                        }
+                    ),
+                    spec=V1PodSpec(
+                        security_context=get_executor_pod_security_context(),
+                        containers=[
+                            V1Container(
+                                name=executor_name,
+                                image=executor.image,
+                                command=["/bin/sh", "-c"],
+                                args=[self._build_command_string(executor)],
+                                working_dir=executor.workdir,
+                                env=[
+                                    V1EnvVar(name=key, value=value)
+                                    for key, value in executor.env.items()
+                                ]
+                                if executor.env is not None
+                                else [],
+                                resources=V1ResourceRequirements(
+                                    limits=resource,
+                                    requests=resource,
+                                ),
+                                volume_mounts=[
+                                    V1VolumeMount(
+                                        name=core_constants.K8s.COMMON_PVC_VOLUME_NAME,
+                                        mount_path=volume,
+                                    )
+                                    for volume in self.task.volumes or []
+                                ]
+                                + _volume_pvc_mount
+                                + get_executor_security_volume_mount(),
+                                image_pull_policy=core_constants.K8s.IMAGE_PULL_POLICY,
+                                security_context=get_executor_container_security_context(),
+                            )
+                        ],
+                        volumes=[
+                            V1Volume(
+                                name=core_constants.K8s.COMMON_PVC_VOLUME_NAME,
+                                persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(
+                                    claim_name=f"{core_constants.K8s.PVC_PREFIX}-{self.task_id}"
+                                ),
                             ),
-                            volume_mounts=[
-                                V1VolumeMount(
-                                    name=core_constants.K8s.COMMON_PVC_VOLUME_NAME,
-                                    mount_path=volume,
-                                )
-                                for volume in self.task.volumes or []
-                            ]
-                            + _volume_pvc_mount
-                            + get_executor_security_volume_mount(),
-                            image_pull_policy=core_constants.K8s.IMAGE_PULL_POLICY,
-                            security_context=get_executor_container_security_context(),
-                        )
-                    ],
-                    volumes=[
-                        V1Volume(
-                            name=core_constants.K8s.COMMON_PVC_VOLUME_NAME,
-                            persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(
-                                claim_name=f"{core_constants.K8s.PVC_PREFIX}-{self.task_id}"
-                            ),
-                        ),
-                    ]
-                    + get_executor_security_volume(),
-                    restart_policy=core_constants.K8s.RESTART_POLICY,
+                        ]
+                        + get_executor_security_volume(),
+                        restart_policy=core_constants.K8s.RESTART_POLICY,
+                    ),
                 ),
-            )
-            await create_pod_with_backoff(pod_manifest, executor_name)
+            ),
+        )
+        return await create_job_with_backoff(job_manifest, executor_name)
 
-    async def monitor_executors(self) -> None:
-        """Monitor the executors and log details in TaskDB."""
-        if not self.task_pool:
-            return
+    async def monitor_executor_job(self, executor: TesExecutor, idx: int) -> bool:
+        """Monitor the executor job and log details in TaskDB.
 
-        pod_names_to_monitor = set(self.task_pool)
-        active_pod_names = set(pod_names_to_monitor)
+        Args:
+            executor: Executor object.
+            idx: Index of the executor.
 
-        if not active_pod_names:
-            logger.info("No pods provided to monitor.")
-            return
+        Returns:
+            True if executor completed successfully, False otherwise.
+        """
+        executor_name = f"{core_constants.K8s.TE_PREFIX}-{self.task_id}-{idx}"
 
-        label_selector = f"service={core_constants.K8s.TE_PREFIX},parent={core_constants.K8s.TEXAM_PREFIX}-{self.task_id}"  # noqa: E501
         timeout = int(
             os.getenv(
                 "MONITOR_TIMEOUT_SECONDS", core_constants.Texam.MONITOR_TIMEOUT_SECONDS
             )
         )
-        stream_args = {
-            "namespace": self.kubernetes_client.namespace,
-            "label_selector": label_selector,
-            "timeout_seconds": timeout,
-        }
 
         try:
             w = watch.Watch()
-            start_time = time.time()
-            logger.info(
-                f"Starting watch for pods with label selector: {label_selector}"
-            )
+            logger.info(f"Starting watch for job: {executor_name}")
 
-            stream_func = self.kubernetes_client.core_api.list_namespaced_pod
-            event_stream = await asyncio.to_thread(w.stream, stream_func, **stream_args)
-            for event in event_stream:
+            # Watch for job completion
+            for event in w.stream(
+                self.kubernetes_client.batch_api.list_namespaced_job,
+                namespace=self.kubernetes_client.namespace,
+                field_selector=f"metadata.name={executor_name}",
+                timeout_seconds=timeout,
+            ):
                 if not isinstance(event, dict):
                     continue
-                event_type = event["type"]
-                pod = event["object"]
-                pod_name = str(pod.metadata.name)
 
-                if pod_name not in active_pod_names:
+                event_type = event["type"]
+                job = event["object"]
+
+                if job.metadata.name != executor_name:
                     continue
 
-                logger.debug(
-                    f"Event: {event_type}, Pod: {pod_name}, Phase: {pod.status.phase}"
-                )
-                await self._process_pod_event(pod, active_pod_names)
+                logger.debug(f"Job event: {event_type}, Job: {executor_name}")
 
-                if not active_pod_names:
-                    w.stop()
-                    logger.info(
-                        "All monitored pods processed in "
-                        f"{time.time() - start_time:.2f} seconds"
-                    )
-                    break
+                # Check job status
+                if job.status and job.status.conditions:
+                    for condition in job.status.conditions:
+                        if condition.type == "Complete" and condition.status == "True":
+                            # Job completed successfully
+                            logs_stdout = await self._get_job_logs(executor_name)
+                            await self.db.update_executor_log(
+                                executor_name,
+                                PodPhase.SUCCEEDED.value,
+                                logs_stdout,
+                                None,
+                            )
+                            logger.info(f"Job {executor_name} completed successfully")
+                            w.stop()
+                            return True
+                        elif condition.type == "Failed" and condition.status == "True":
+                            # Job failed
+                            logs_stdout = await self._get_job_logs(executor_name)
+                            await self.db.update_executor_log(
+                                executor_name,
+                                PodPhase.FAILED.value,
+                                logs_stdout,
+                                f"Job failed: {condition.message}",
+                            )
+                            logger.error(
+                                f"Job {executor_name} failed: {condition.message}"
+                            )
+                            w.stop()
+                            return False
 
-            await self._handle_unresolved_pods(active_pod_names, timeout, start_time)
-
-        except asyncio.CancelledError:
-            logger.info(
-                f"Pod watch task cancelled in {time.time() - start_time:.2f} seconds"
+            # If we reach here, the timeout was reached
+            logger.error(
+                f"Job {executor_name} monitoring timed out after {timeout} seconds"
             )
-        except Exception as e:
-            logger.exception(f"Error in watch stream: {e}")
-            raise
-
-    async def _process_pod_event(self, pod: V1Pod, active_pod_names: set) -> None:
-        """Processes a single pod event."""
-        # Poiesis adds these fields, so we can safely assert them
-        assert pod.metadata is not None
-        assert pod.status is not None
-
-        pod_name = str(pod.metadata.name)
-        pod_phase = pod.status.phase if pod.status else None
-
-        if failure_reason := self._check_container_failure(pod):
-            await self._handle_pod_failure(pod_name, failure_reason)
-            self._remove_pod_from_pool(pod_name, active_pod_names)
-            return
-
-        if pod_phase and pod_phase in (PodPhase.SUCCEEDED.value, PodPhase.FAILED.value):
-            logs_stdout, logs_stderr = await self._get_pod_logs(pod_name, pod_phase)
             await self.db.update_executor_log(
-                pod_name,
-                pod_phase,
-                logs_stdout,
-                logs_stderr if pod_phase == PodPhase.FAILED.value else None,
+                executor_name,
+                PodPhase.FAILED.value,
+                stdout=None,
+                stderr=f"Job monitoring timed out after {timeout} seconds.",
             )
-            logger.info(
-                f"Pod {pod_name} completed with status: {pod_phase}. Logs captured "
-                "(if available)."
+            w.stop()
+            return False
+
+        except Exception as e:
+            logger.exception(f"Error monitoring job {executor_name}: {e}")
+            await self.db.update_executor_log(
+                executor_name,
+                PodPhase.FAILED.value,
+                stdout=None,
+                stderr=f"Error monitoring job: {str(e)}",
             )
-            self._remove_pod_from_pool(pod_name, active_pod_names)
+            return False
 
-        elif pod_phase and pod_phase == PodPhase.UNKNOWN.value:
-            logger.warning(f"Pod {pod_name} is in an Unknown state.")
+    async def _get_job_logs(self, job_name: str) -> str | None:
+        """Get logs from the job's pod.
 
-    def _check_container_failure(self, pod: V1Pod) -> str | None:
-        """Checks for container failures and returns the reason if found.
+        Args:
+            job_name: Name of the job.
 
-        Executor pod might be in pending state, if the pod is in pending state, it
-        means that the pod might fail to start, that is why we need to check for
-        container failures.
+        Returns:
+            Job logs or None if not available.
         """
-        pod_phase = pod.status.phase if pod.status else None
+        try:
+            # Get pods for this job
+            pods = self.kubernetes_client.core_api.list_namespaced_pod(
+                namespace=self.kubernetes_client.namespace,
+                label_selector=f"job-name={job_name}",
+            )
 
-        # If container is failing to start, it will be in the init_container_statuses
-        # or container_statuses list
-        if pod.status is None:
-            return None
+            if pods.items:
+                # Get logs from the first pod
+                pod = pods.items[0]
+                if pod.metadata and pod.metadata.name:
+                    pod_name = pod.metadata.name
+                    return await self.kubernetes_client.get_pod_log(pod_name)
+        except Exception as e:
+            logger.warning(f"Could not get logs for job {job_name}: {e}")
 
-        all_container_statuses = (pod.status.init_container_statuses or []) + (
-            pod.status.container_statuses or []
-        )
-
-        assert pod.metadata is not None
-
-        if pod_phase == PodPhase.PENDING.value or (
-            pod.status and all_container_statuses
-        ):
-            for status in all_container_statuses:
-                if status.state and status.state.waiting:
-                    container_name = status.name or "Unknown"
-                    logger.info(
-                        f"Pending pod "
-                        f"{pod.metadata.name if pod.metadata else 'Unknown'} "
-                        f"has container {container_name} in waiting state with reason: "
-                        f"{status.state.waiting.reason}"
-                    )
-                    if status.state.waiting.reason in CRITICAL_WAITING_REASONS:
-                        return status.state.waiting.reason
         return None
-
-    async def _handle_pod_failure(self, pod_name: str, failure_reason: str) -> None:
-        """Handles pod failure and updates the database."""
-        error_log_message = f"Pod failed due to container error: {failure_reason}"
-        try:
-            await self.db.update_executor_log(
-                pod_name, PodPhase.FAILED.value, stdout=None, stderr=error_log_message
-            )
-            logger.info(
-                f"Pod {pod_name} marked as Failed in DB due to container error: "
-                f"{failure_reason}"
-            )
-        except Exception as e:
-            logger.error(f"Failed to update DB for failed pod {pod_name}: {e}")
-
-    async def _get_pod_logs(
-        self, pod_name: str, pod_phase: str
-    ) -> tuple[str | None, str]:
-        """Retrieves pod logs, handling potential errors.
-
-        Logs are retrieved from the pod, if the pod is in failed state, we retrieve
-        the logs from the pod, if the pod is in succeeded state, we don't retrieve
-        the logs from the pod. This help in case the pod is in pending state or couldn't
-        start due to some reason.
-        """
-        logs_stdout = None
-        logs_stderr = f"Pod phase reported as {pod_phase} by Kubernetes."
-        try:
-            logs_stdout = await self.kubernetes_client.get_pod_log(pod_name)
-        except Exception as e:
-            logger.warning(
-                f"Could not get logs for pod {pod_name} in phase {pod_phase}: {e}"
-            )
-            logs_stderr += f" Log retrieval failed: {str(e)}"
-        return logs_stdout, logs_stderr
-
-    def _remove_pod_from_pool(self, pod_name: str, active_pod_names: set) -> None:
-        """Removes a pod from the active pool and task pool."""
-        active_pod_names.discard(pod_name)
-        if pod_entry := next((p for p in self.task_pool if p == pod_name), None):
-            with contextlib.suppress(ValueError):
-                self.task_pool.remove(pod_entry)
-
-    async def _handle_unresolved_pods(
-        self, active_pod_names: set, timeout: int, start_time: float
-    ) -> None:
-        """Handles unresolved pods after the watch ends."""
-        if active_pod_names:
-            logger.warning(
-                f"Watch ended with {len(active_pod_names)} unresolved pods: "
-                f"{active_pod_names}, Time taken: {time.time() - start_time:.2f} "
-                "seconds"
-            )
-            for pod_name in active_pod_names.copy():
-                logger.error(
-                    f"Pod {pod_name} did not reach a terminal state before watch "
-                    "timeout."
-                )
-                try:
-                    await self.kubernetes_client.delete_pod(pod_name)
-                    await self.db.update_executor_log(
-                        pod_name,
-                        PodPhase.FAILED.value,
-                        stdout=None,
-                        stderr=f"Pod monitoring timed out after {timeout} seconds.",
-                    )
-                except Exception as e:
-                    logger.error(
-                        f"Failed to update DB for timed-out pod {pod_name}: {e}"
-                    )
-                self._remove_pod_from_pool(pod_name, active_pod_names)
-                self.failed = True
-
-    async def cleanup_pods(self) -> None:
-        """Clean up completed executor pods to free PVC references.
-
-        Deletes pods that allow PVCs to be properly cleaned up.
-        """
-        if not self.pods_to_cleanup:
-            logger.debug("No executor pods to clean up")
-            return
-
-        logger.info(f"Starting cleanup of {len(self.pods_to_cleanup)} executor pods")
-        cleanup_count = 0
-
-        for pod_name in self.pods_to_cleanup[:]:
-            try:
-                await self.kubernetes_client.delete_pod(pod_name)
-                cleanup_count += 1
-            except Exception as e:
-                logger.warning(f"Could not cleanup pod {pod_name}: {e}")
-
-        logger.debug(
-            "Pod cleanup completed. Cleaned up "
-            f"{cleanup_count}/{len(self.pods_to_cleanup)} pods"
-        )
 
     async def message(self) -> None:
         """Send message to TORC."""


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #63

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Refactor Texam executor orchestration to run each executor sequentially as a Kubernetes Job, with immediate failure handling for subsequent executors; simplify logging and monitoring logic and update database interactions accordingly.

Bug Fixes:
- Ensure executors run one after another and mark all remaining executors as failed if any executor fails

Enhancements:
- Replace pod-based parallel creation and monitoring with job-based sequential execution, unified backoff and retry logic, and streamlined manifest building
- Simplify logs retrieval into a dedicated method and remove deprecated pod monitoring utilities
- Update MongoDB update_executor_log to accept job names and store provided stdout directly

Build:
- Use Docker Buildx in Makefile for multi-platform builds with automatic push

Chores:
- Remove unused critical waiting reasons constant from Texam service