### PR TITLE
perf(torc): skip `TIF`/`TOF` when no inputs/outputs

### DIFF
--- a/poiesis/core/services/torc/torc.py
+++ b/poiesis/core/services/torc/torc.py
@@ -211,6 +211,10 @@ class Torc:
         else:
             logger.debug(f"Task {name} has no inputs")
 
+        if inputs is None or len(inputs) == 0:
+            logger.info(f"Task {name} has no inputs, skipping TIF execution")
+            return
+
         try:
             tif_executor = TorcTifExecution(name, inputs)
             await tif_executor.execute()
@@ -267,6 +271,10 @@ class Torc:
             logger.debug(f"Task {name} has {len(outputs)} outputs")
         else:
             logger.debug(f"Task {name} has no outputs")
+
+        if outputs is None or len(outputs) == 0:
+            logger.info(f"Task {name} has no outputs, skipping TOF execution")
+            return
 
         try:
             tof_executor = TorcTofExecution(name, outputs)


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #36

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Skip TIF and TOF execution when there are no inputs or outputs to avoid unnecessary processing and improve performance

Enhancements:
- Add early return in tif_execution when inputs list is empty or None
- Add early return in tof_execution when outputs list is empty or None