### PR TITLE
fix: improve cancel tasks with bulk deletion

### DIFF
--- a/deployment/dev.yaml
+++ b/deployment/dev.yaml
@@ -26,10 +26,18 @@ rules:
   - apiGroups: [""]
     resources:
       ["pods", "pods/log", "persistentvolumeclaims", "secrets", "configmaps"]
-    verbs: ["create", "get", "list", "watch", "delete", "patch", "update"]
+    verbs:
+      [
+        "create",
+        "get",
+        "list",
+        "watch",
+        "delete",
+        "deletecollection",
+      ]
   - apiGroups: ["batch"]
     resources: ["jobs"]
-    verbs: ["create", "get", "list", "watch", "delete"]
+    verbs: ["create", "get", "list", "watch", "delete", "deletecollection"]
 ...
 ---
 # ROLE BINDING: Binds the namespaced Role to our ServiceAccount

--- a/deployment/helm/templates/_helper.tpl
+++ b/deployment/helm/templates/_helper.tpl
@@ -96,7 +96,7 @@ Namespaced RBAC rules (include Jobs - they are namespace-scoped, not cluster-sco
         "verbs" (list "get"))
     (dict "apiGroups" (list "batch")
         "resources" (list "jobs")
-        "verbs" (list "create" "get" "list" "watch" "delete"))
+        "verbs" (list "create" "get" "list" "watch" "delete" "deletecollection"))
 }}
 {{ toYaml $namespacedRules | indent 2 }}
 {{- end }}

--- a/deployment/helm/templates/_helper.tpl
+++ b/deployment/helm/templates/_helper.tpl
@@ -90,7 +90,7 @@ Namespaced RBAC rules (include Jobs - they are namespace-scoped, not cluster-sco
 {{- $namespacedRules := list
     (dict "apiGroups" (list "")
         "resources" (list "pods" "persistentvolumeclaims")
-        "verbs" (list "create" "get" "list" "watch" "delete"))
+        "verbs" (list "create" "get" "list" "watch" "delete" "deletecollection"))
     (dict "apiGroups" (list "")
         "resources" (list "pods/log")
         "verbs" (list "get"))

--- a/poiesis/api/controllers/cancel_task.py
+++ b/poiesis/api/controllers/cancel_task.py
@@ -72,19 +72,19 @@ class CancelTaskController(InterfaceController):
         await self.db.update_task_state(self.task_id, TesState.CANCELING)
 
         label_selector = f"tes-task-id={self.task_id}"
-        logger.debug(f"Cancelling all the jobs with label selector: {label_selector}")
+        logger.debug(f"Deleting all the jobs with label selector: {label_selector}")
         try:
             await self.kubernetes_client.delete_jobs_by_label(label_selector)
         except ApiException as e:
             logger.warning(f"Error deleting jobs for task {self.task_id}: {e}")
 
-        logger.debug(f"Cancelling all the pods with label selector: {label_selector}")
+        logger.debug(f"Deleting all the pods with label selector: {label_selector}")
         try:
             await self.kubernetes_client.delete_pods_by_label(label_selector)
         except ApiException as e:
             logger.warning(f"Error deleting pods for task {self.task_id}: {e}")
 
-        logger.debug(f"Cancelling all the PVCs with label selector: {label_selector}")
+        logger.debug(f"Deleting all the PVCs with label selector: {label_selector}")
         try:
             await self.kubernetes_client.delete_pvcs_by_label(label_selector)
         except ApiException as e:

--- a/poiesis/api/controllers/cancel_task.py
+++ b/poiesis/api/controllers/cancel_task.py
@@ -78,6 +78,12 @@ class CancelTaskController(InterfaceController):
         except ApiException as e:
             logger.warning(f"Error deleting jobs for task {self.task_id}: {e}")
 
+        logger.debug(f"Cancelling all the pods with label selector: {label_selector}")
+        try:
+            await self.kubernetes_client.delete_pods_by_label(label_selector)
+        except ApiException as e:
+            logger.warning(f"Error deleting pods for task {self.task_id}: {e}")
+
         logger.debug(f"Cancelling all the PVCs with label selector: {label_selector}")
         try:
             await self.kubernetes_client.delete_pvcs_by_label(label_selector)

--- a/poiesis/api/controllers/cancel_task.py
+++ b/poiesis/api/controllers/cancel_task.py
@@ -1,5 +1,6 @@
 """Controller for canceling tasks."""
 
+import asyncio
 import logging
 from typing import Any
 
@@ -46,6 +47,67 @@ class CancelTaskController(InterfaceController):
         self.user_id = user_id
         self.kubernetes_client = KubernetesAdapter()
 
+    async def _clean_task_resources_and_set_final_state(self) -> None:
+        """Clean up the task resources and set final state."""
+        await self._clean_task_task_resources()
+        await self.db.update_task_state(self.task_id, TesState.CANCELED)
+        logger.info(f"Task {self.task_id} has been canceled and resources cleaned up.")
+
+    async def _clean_task_task_resources(self) -> None:
+        """Clean up the task resources."""
+        label_selector = f"tes-task-id={self.task_id}"
+        logger.debug(f"Deleting all the jobs with label selector: {label_selector}")
+
+        resources = [
+            {
+                "name": "jobs",
+                "list_fn": self.kubernetes_client.list_jobs_by_label,
+                "delete_fn": self.kubernetes_client.delete_jobs_by_label,
+                "log_fail": "Failed to delete all jobs after retries and waiting.",
+            },
+            {
+                "name": "pods",
+                "list_fn": self.kubernetes_client.list_pods_by_label,
+                "delete_fn": self.kubernetes_client.delete_pods_by_label,
+                "log_fail": "Failed to delete all pods after retries and waiting.",
+            },
+            {
+                "name": "PVCs",
+                "list_fn": self.kubernetes_client.list_pvcs_by_label,
+                "delete_fn": self.kubernetes_client.delete_pvcs_by_label,
+                "log_fail": "Failed to delete all PVCs after retries and waiting.",
+            },
+        ]
+
+        max_retries = 3
+        for resource in resources:
+            logger.debug(
+                f"Deleting all the {resource['name']} with "
+                f"label selector: {label_selector}"
+            )
+            try_count = 0
+            try:
+                list_fn = resource["list_fn"]
+                delete_fn = resource["delete_fn"]
+                # We can safely cast here as we know the types in the resources list
+                while (
+                    await list_fn(label_selector)  # type: ignore
+                    and try_count <= max_retries
+                ):
+                    await delete_fn(label_selector)  # type: ignore
+                    try_count += 1
+                    await asyncio.sleep(2 << try_count)
+                if await list_fn(label_selector):  # type: ignore
+                    log_fail = resource["log_fail"]
+
+                    logger.warning(log_fail)
+            except ApiException as e:
+                logger.warning(
+                    f"Error deleting {resource['name']} for task {self.task_id}: {e}"
+                )
+            except TypeError as e:
+                logger.error(f"Error calling function: {e}")
+
     async def execute(self, *args: Any, **kwargs: Any) -> TesCancelTaskResponse:
         """Cancel a task.
 
@@ -62,34 +124,18 @@ class CancelTaskController(InterfaceController):
         if task.user_id != self.user_id:
             raise NotFoundException(f"Task {self.task_id} not found for user")
 
-        if task.state == TesState.COMPLETE:
-            raise BadRequestException(f"Task {self.task_id} is already completed")
-        elif task.state == TesState.CANCELED:
-            raise BadRequestException(f"Task {self.task_id} is already canceled")
-        elif task.state == TesState.CANCELING:
-            raise BadRequestException(f"Task {self.task_id} is already being canceled")
+        if task.state in (
+            TesState.COMPLETE,
+            TesState.CANCELED,
+            TesState.CANCELING,
+        ):
+            raise BadRequestException(
+                f"Task {self.task_id} is already in a terminal state"
+                f": {task.state.value}"
+            )
 
         await self.db.update_task_state(self.task_id, TesState.CANCELING)
 
-        label_selector = f"tes-task-id={self.task_id}"
-        logger.debug(f"Deleting all the jobs with label selector: {label_selector}")
-        try:
-            await self.kubernetes_client.delete_jobs_by_label(label_selector)
-        except ApiException as e:
-            logger.warning(f"Error deleting jobs for task {self.task_id}: {e}")
-
-        logger.debug(f"Deleting all the pods with label selector: {label_selector}")
-        try:
-            await self.kubernetes_client.delete_pods_by_label(label_selector)
-        except ApiException as e:
-            logger.warning(f"Error deleting pods for task {self.task_id}: {e}")
-
-        logger.debug(f"Deleting all the PVCs with label selector: {label_selector}")
-        try:
-            await self.kubernetes_client.delete_pvcs_by_label(label_selector)
-        except ApiException as e:
-            logger.warning(f"Error deleting PVCs for task {self.task_id}: {e}")
-
-        await self.db.update_task_state(self.task_id, TesState.CANCELED)
+        asyncio.create_task(self._clean_task_resources_and_set_final_state())
 
         return TesCancelTaskResponse()

--- a/poiesis/api/controllers/create_task.py
+++ b/poiesis/api/controllers/create_task.py
@@ -34,6 +34,7 @@ from poiesis.core.constants import (
     get_infrastructure_pod_security_context,
     get_infrastructure_security_volume,
     get_infrastructure_security_volume_mount,
+    get_labels,
     get_message_broker_envs,
     get_mongo_envs,
     get_poiesis_core_constants,
@@ -98,15 +99,24 @@ class CreateTaskController(InterfaceController):
             metadata=V1ObjectMeta(
                 name=torc_job_name,
                 namespace=core_constants.K8s.K8S_NAMESPACE,
-                labels={
-                    "service": core_constants.K8s.TORC_PREFIX,
-                    "name": torc_job_name,
-                    "parent": "poiesis-api",
-                },
+                labels=get_labels(
+                    component=core_constants.K8s.TORC_PREFIX,
+                    name=torc_job_name,
+                    task_id=str(self.task.id),
+                    parent="poiesis-api",
+                ),
             ),
             spec=V1JobSpec(
                 backoff_limit=int(core_constants.K8s.BACKOFF_LIMIT),
                 template=V1PodTemplateSpec(
+                    metadata=V1ObjectMeta(
+                        labels=get_labels(
+                            component=core_constants.K8s.TORC_PREFIX,
+                            name=torc_job_name,
+                            task_id=str(self.task.id),
+                            parent="poiesis-api",
+                        ),
+                    ),
                     spec=V1PodSpec(
                         service_account_name=core_constants.K8s.SERVICE_ACCOUNT_NAME,
                         security_context=get_infrastructure_pod_security_context(),

--- a/poiesis/core/adaptors/kubernetes/kubernetes.py
+++ b/poiesis/core/adaptors/kubernetes/kubernetes.py
@@ -177,6 +177,62 @@ class KubernetesAdapter(KubernetesPort):
             logger.error(f"Error listing pods: {e}")
             raise
 
+    async def list_pods_by_label(self, label_selector: str) -> list[client.V1Pod]:
+        """List pods by label selector.
+
+        Args:
+            label_selector: The label selector.
+        """
+        try:
+            api_response = await asyncio.to_thread(
+                self.core_api.list_namespaced_pod,
+                namespace=self.namespace,
+                label_selector=label_selector,
+            )
+            pods: list[client.V1Pod] = api_response.items
+            return pods
+        except ApiException as e:
+            logger.error(f"Error listing pods by label: {e}")
+            raise
+
+    async def list_jobs_by_label(self, label_selector: str) -> list[client.V1Job]:
+        """List jobs by label selector.
+
+        Args:
+            label_selector: The label selector.
+        """
+        try:
+            api_response = await asyncio.to_thread(
+                self.batch_api.list_namespaced_job,
+                namespace=self.namespace,
+                label_selector=label_selector,
+            )
+            jobs: list[client.V1Job] = api_response.items
+            return jobs
+        except ApiException as e:
+            logger.error(f"Error listing jobs by label: {e}")
+            raise
+
+    async def list_pvcs_by_label(
+        self, label_selector: str
+    ) -> list[client.V1PersistentVolumeClaim]:
+        """List PVCs by label selector.
+
+        Args:
+            label_selector: The label selector.
+        """
+        try:
+            api_response = await asyncio.to_thread(
+                self.core_api.list_namespaced_persistent_volume_claim,
+                namespace=self.namespace,
+                label_selector=label_selector,
+            )
+            pvcs: list[client.V1PersistentVolumeClaim] = api_response.items
+            return pvcs
+        except ApiException as e:
+            logger.error(f"Error listing PVCs by label: {e}")
+            raise
+
     async def get_pod_log(self, name: str) -> str:
         """Get log of a pod.
 

--- a/poiesis/core/adaptors/kubernetes/kubernetes.py
+++ b/poiesis/core/adaptors/kubernetes/kubernetes.py
@@ -205,7 +205,7 @@ class KubernetesAdapter(KubernetesPort):
                 name=name,
                 namespace=self.namespace,
             )
-            logger.info(f"Deleted job {name} from namespace {self.namespace}")
+            logger.debug(f"Deleted job {name} from namespace {self.namespace}")
         except ApiException as e:
             if e.status != HTTPStatus.NOT_FOUND:
                 logger.error(f"Error deleting job: {e}")
@@ -225,7 +225,7 @@ class KubernetesAdapter(KubernetesPort):
                 label_selector=label_selector,
                 body=delete_options,
             )
-            logger.info(
+            logger.debug(
                 f"Deleted jobs with label selector '{label_selector}' from "
                 f"namespace {self.namespace}"
             )
@@ -246,11 +246,32 @@ class KubernetesAdapter(KubernetesPort):
                 namespace=self.namespace,
                 label_selector=label_selector,
             )
-            logger.info(
+            logger.debug(
                 f"Deleted PVCs with label selector '{label_selector}' from "
                 f"namespace {self.namespace}"
             )
         except ApiException as e:
             if e.status != HTTPStatus.NOT_FOUND:
                 logger.error(f"Error deleting PVCs by label: {e}")
+                raise
+
+    async def delete_pods_by_label(self, label_selector: str) -> None:
+        """Delete pods by label selector.
+
+        Args:
+            label_selector: The label selector.
+        """
+        try:
+            await asyncio.to_thread(
+                self.core_api.delete_collection_namespaced_pod,
+                namespace=self.namespace,
+                label_selector=label_selector,
+            )
+            logger.debug(
+                f"Deleted pods with label selector '{label_selector}' from "
+                f"namespace {self.namespace}"
+            )
+        except ApiException as e:
+            if e.status != HTTPStatus.NOT_FOUND:
+                logger.error(f"Error deleting pods by label: {e}")
                 raise

--- a/poiesis/core/adaptors/kubernetes/kubernetes.py
+++ b/poiesis/core/adaptors/kubernetes/kubernetes.py
@@ -218,12 +218,10 @@ class KubernetesAdapter(KubernetesPort):
             label_selector: The label selector.
         """
         try:
-            delete_options = client.V1DeleteOptions(propagation_policy="Foreground")
             await asyncio.to_thread(
                 self.batch_api.delete_collection_namespaced_job,
                 namespace=self.namespace,
                 label_selector=label_selector,
-                body=delete_options,
             )
             logger.debug(
                 f"Deleted jobs with label selector '{label_selector}' from "
@@ -239,12 +237,17 @@ class KubernetesAdapter(KubernetesPort):
 
         Args:
             label_selector: The label selector.
+
+        Notes:
+            Uses 'Foreground' propagation policy to ensure dependent resources are
+            deleted before the PVC is removed.
         """
         try:
             await asyncio.to_thread(
                 self.core_api.delete_collection_namespaced_persistent_volume_claim,
                 namespace=self.namespace,
                 label_selector=label_selector,
+                propagation_policy="Foreground",
             )
             logger.debug(
                 f"Deleted PVCs with label selector '{label_selector}' from "

--- a/poiesis/core/constants.py
+++ b/poiesis/core/constants.py
@@ -556,3 +556,34 @@ def get_executor_security_volume_mount() -> list[V1VolumeMount]:
             read_only=True,
         )
     ]
+
+
+def get_labels(
+    component: str,
+    task_id: str,
+    name: str | None = None,
+    parent: str | None = None,
+) -> dict[str, str]:
+    """Get the labels for a job or a PVC.
+
+    Args:
+        component: The component that is creating the resource.
+        task_id: The id of the task.
+        name: The name of the resource.
+        parent: The parent of the resource.
+
+    Returns:
+        The labels for the resource.
+    """
+    labels = {
+        "app.kubernetes.io/name": "poiesis",
+        "app.kubernetes.io/component": component,
+        "app.kubernetes.io/instance": task_id,
+        "tes-task-id": task_id,
+    }
+    if name:
+        labels["app.kubernetes.io/name"] = name
+    if parent:
+        labels["app.kubernetes.io/part-of"] = parent
+
+    return labels

--- a/poiesis/core/constants.py
+++ b/poiesis/core/constants.py
@@ -578,7 +578,6 @@ def get_labels(
     labels = {
         "app.kubernetes.io/name": "poiesis",
         "app.kubernetes.io/component": component,
-        "app.kubernetes.io/instance": task_id,
         "tes-task-id": task_id,
     }
     if name:

--- a/poiesis/core/constants.py
+++ b/poiesis/core/constants.py
@@ -576,12 +576,11 @@ def get_labels(
         The labels for the resource.
     """
     labels = {
-        "app.kubernetes.io/name": "poiesis",
         "app.kubernetes.io/component": component,
         "tes-task-id": task_id,
     }
     if name:
-        labels["app.kubernetes.io/name"] = name
+        labels["app.kubernetes.io/resource-name"] = name
     if parent:
         labels["app.kubernetes.io/part-of"] = parent
 

--- a/poiesis/core/services/texam/texam.py
+++ b/poiesis/core/services/texam/texam.py
@@ -32,6 +32,7 @@ from poiesis.core.constants import (
     get_executor_container_security_context,
     get_executor_pod_security_context,
     get_executor_security_volume,
+    get_labels,
     get_poiesis_core_constants,
 )
 from poiesis.core.ports.message_broker import Message, MessageStatus
@@ -315,6 +316,9 @@ class Texam:
             {k: v for k, v in _resource.items() if v is not None} if _resource else {}
         )
 
+        if self.task_id is None:
+            raise ValueError("task_id cannot be None")
+
         _parent = f"{core_constants.K8s.TEXAM_PREFIX}-{self.task_id}"
 
         return V1Job(
@@ -322,11 +326,12 @@ class Texam:
             kind="Job",
             metadata=V1ObjectMeta(
                 name=executor_name,
-                labels={
-                    "service": core_constants.K8s.TE_PREFIX,
-                    "parent": _parent,
-                    "name": executor_name,
-                },
+                labels=get_labels(
+                    component=core_constants.K8s.TE_PREFIX,
+                    task_id=self.task_id,
+                    name=executor_name,
+                    parent=f"{core_constants.K8s.TEXAM_PREFIX}-{self.task_id}",
+                ),
             ),
             spec=V1JobSpec(
                 # Note: Backoff limit is set to 0 to fail immediately when pod fails.
@@ -340,11 +345,12 @@ class Texam:
                 ),
                 template=V1PodTemplateSpec(
                     metadata=V1ObjectMeta(
-                        labels={
-                            "service": core_constants.K8s.TE_PREFIX,
-                            "parent": _parent,
-                            "name": executor_name,
-                        }
+                        labels=get_labels(
+                            component=core_constants.K8s.TE_PREFIX,
+                            task_id=self.task_id,
+                            name=executor_name,
+                            parent=f"{core_constants.K8s.TEXAM_PREFIX}-{self.task_id}",
+                        )
                     ),
                     spec=V1PodSpec(
                         security_context=get_executor_pod_security_context(),

--- a/poiesis/core/services/texam/texam.py
+++ b/poiesis/core/services/texam/texam.py
@@ -317,7 +317,7 @@ class Texam:
         )
 
         if self.task_id is None:
-            raise ValueError("task_id cannot be None")
+            raise ValueError(f"task_id cannot be None for executor '{executor_name}'")
 
         _parent = f"{core_constants.K8s.TEXAM_PREFIX}-{self.task_id}"
 

--- a/poiesis/core/services/torc/torc.py
+++ b/poiesis/core/services/torc/torc.py
@@ -17,7 +17,7 @@ from poiesis.api.tes.models import (
     TesTask,
 )
 from poiesis.core.adaptors.kubernetes.kubernetes import KubernetesAdapter
-from poiesis.core.constants import get_poiesis_core_constants
+from poiesis.core.constants import get_labels, get_poiesis_core_constants
 from poiesis.core.services.torc.torc_texam_execution import TorcTexamExecution
 from poiesis.core.services.torc.torc_tif_execution import TorcTifExecution
 from poiesis.core.services.torc.torc_tof_execution import TorcTofExecution
@@ -164,11 +164,12 @@ class Torc:
             kind="PersistentVolumeClaim",
             metadata=V1ObjectMeta(
                 name=pvc_name,
-                labels={
-                    "service": core_constants.K8s.PVC_PREFIX,
-                    "name": pvc_name,
-                    "parent": core_constants.K8s.TORC_PREFIX,
-                },
+                labels=get_labels(
+                    component=core_constants.K8s.PVC_PREFIX,
+                    task_id=name,
+                    name=pvc_name,
+                    parent=f"{core_constants.K8s.TORC_PREFIX}-{name}",
+                ),
             ),
             spec=V1PersistentVolumeClaimSpec(
                 access_modes=[core_constants.K8s.PVC_ACCESS_MODE]

--- a/poiesis/core/services/torc/torc_execution_template.py
+++ b/poiesis/core/services/torc/torc_execution_template.py
@@ -112,6 +112,7 @@ class TorcExecutionTemplate(ABC):
             spec=V1JobSpec(
                 backoff_limit=int(core_constants.K8s.BACKOFF_LIMIT),
                 template=V1PodTemplateSpec(
+                    metadata=metadata,
                     spec=V1PodSpec(
                         security_context=get_infrastructure_pod_security_context(),
                         containers=[

--- a/poiesis/core/services/torc/torc_texam_execution.py
+++ b/poiesis/core/services/torc/torc_texam_execution.py
@@ -23,6 +23,7 @@ from poiesis.core.constants import (
     get_infrastructure_pod_security_context,
     get_infrastructure_security_volume,
     get_infrastructure_security_volume_mount,
+    get_labels,
     get_message_broker_envs,
     get_mongo_envs,
     get_poiesis_core_constants,
@@ -97,14 +98,23 @@ class TorcTexamExecution(TorcExecutionTemplate):
             kind="Job",
             metadata=V1ObjectMeta(
                 name=texam_name,
-                labels={
-                    "service": core_constants.K8s.TEXAM_PREFIX,
-                    "parent": f"{core_constants.K8s.TORC_PREFIX}-{self.id}",
-                    "name": texam_name,
-                },
+                labels=get_labels(
+                    component=core_constants.K8s.TEXAM_PREFIX,
+                    task_id=self.id,
+                    name=texam_name,
+                    parent=f"{core_constants.K8s.TORC_PREFIX}-{self.id}",
+                ),
             ),
             spec=V1JobSpec(
                 template=V1PodTemplateSpec(
+                    metadata=V1ObjectMeta(
+                        labels=get_labels(
+                            component=core_constants.K8s.TEXAM_PREFIX,
+                            name=texam_name,
+                            task_id=self.id,
+                            parent=f"{core_constants.K8s.TORC_PREFIX}-{self.id}",
+                        ),
+                    ),
                     spec=V1PodSpec(
                         service_account_name=core_constants.K8s.SERVICE_ACCOUNT_NAME,
                         security_context=get_infrastructure_pod_security_context(),
@@ -199,7 +209,7 @@ class TorcTexamExecution(TorcExecutionTemplate):
                         ],
                         restart_policy=core_constants.K8s.RESTART_POLICY,
                         volumes=get_infrastructure_security_volume(),
-                    )
+                    ),
                 ),
                 ttl_seconds_after_finished=_ttl,
             ),

--- a/poiesis/core/services/torc/torc_tif_execution.py
+++ b/poiesis/core/services/torc/torc_tif_execution.py
@@ -8,7 +8,7 @@ from kubernetes.client import (
 )
 
 from poiesis.api.tes.models import TesInput
-from poiesis.core.constants import get_poiesis_core_constants
+from poiesis.core.constants import get_labels, get_poiesis_core_constants
 from poiesis.core.services.torc.torc_execution_template import TorcExecutionTemplate
 
 core_constants = get_poiesis_core_constants()
@@ -69,11 +69,12 @@ class TorcTifExecution(TorcExecutionTemplate):
 
         metadata = V1ObjectMeta(
             name=tif_job_name,
-            labels={
-                "service": core_constants.K8s.TIF_PREFIX,
-                "name": tif_job_name,
-                "parent": f"{core_constants.K8s.TORC_PREFIX}-{self.id}",
-            },
+            labels=get_labels(
+                component=core_constants.K8s.TIF_PREFIX,
+                task_id=self.id,
+                name=tif_job_name,
+                parent=f"{core_constants.K8s.TORC_PREFIX}-{self.id}",
+            ),
         )
 
         commands: list[str] = ["poiesis", "tif", "run"]

--- a/poiesis/core/services/torc/torc_tof_execution.py
+++ b/poiesis/core/services/torc/torc_tof_execution.py
@@ -8,7 +8,7 @@ from kubernetes.client import (
 )
 
 from poiesis.api.tes.models import TesOutput
-from poiesis.core.constants import get_poiesis_core_constants
+from poiesis.core.constants import get_labels, get_poiesis_core_constants
 from poiesis.core.services.torc.torc_execution_template import TorcExecutionTemplate
 
 core_constants = get_poiesis_core_constants()
@@ -74,11 +74,12 @@ class TorcTofExecution(TorcExecutionTemplate):
 
         metadata = V1ObjectMeta(
             name=tof_job_name,
-            labels={
-                "service": core_constants.K8s.TOF_PREFIX,
-                "name": tof_job_name,
-                "parent": f"{core_constants.K8s.TORC_PREFIX}-{self.id}",
-            },
+            labels=get_labels(
+                component=core_constants.K8s.TOF_PREFIX,
+                task_id=self.id,
+                name=tof_job_name,
+                parent=f"{core_constants.K8s.TORC_PREFIX}-{self.id}",
+            ),
         )
         commands: list[str] = ["poiesis", "tof", "run"]
         args: list[str] = ["--name", task_id, "--outputs", outputs]


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #66 
<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Improve task cancellation by introducing bulk listing and deletion of Kubernetes resources with retries, standardize resource labels via a helper function, and update RBAC policies to support bulk deletion

New Features:
- Add get_labels utility for generating consistent Kubernetes resource labels
- Add list_*_by_label and delete_*_by_label methods to KubernetesAdapter for bulk operations

Enhancements:
- Refactor CancelTaskController to clean up jobs, pods, and PVCs in bulk with retries and async finalization
- Standardize metadata labels in job, pod, and PVC manifests across Texam and Torc services using get_labels
- Validate presence of task_id when creating executor jobs

Deployment:
- Update RBAC rules in dev and Helm charts to include deletecollection verbs for pods, PVCs, and jobs