### PR TITLE
fix: validate PVC deletion

### DIFF
--- a/poiesis/core/adaptors/kubernetes/kubernetes.py
+++ b/poiesis/core/adaptors/kubernetes/kubernetes.py
@@ -110,6 +110,10 @@ class KubernetesAdapter(KubernetesPort):
 
     async def delete_pvc(self, name: str) -> None:
         """Delete a Persistent Volume Claim."""
+        if not name or not name.strip():
+            logger.warning("Attempted to delete PVC with empty name, skipping")
+            return
+
         try:
             await asyncio.to_thread(
                 self.core_api.delete_namespaced_persistent_volume_claim,

--- a/poiesis/core/constants.py
+++ b/poiesis/core/constants.py
@@ -93,7 +93,7 @@ class PoiesisCoreConstants:
         S3_SECRET_NAME = os.getenv("POIESIS_S3_SECRET_NAME")
         MONGODB_SECRET_NAME = os.getenv("POIESIS_MONGO_SECRET_NAME")
         SERVICE_ACCOUNT_NAME = os.getenv("POIESIS_SERVICE_ACCOUNT_NAME")
-        BACKOFF_LIMIT = os.getenv("BACKOFF_LIMIT", "1")
+        BACKOFF_LIMIT = 0
         CONFIGMAP_NAME = os.getenv("POIESIS_CORE_CONFIGMAP_NAME")
         RESTART_POLICY = os.getenv("POIESIS_RESTART_POLICY", "Never")
         IMAGE_PULL_POLICY = os.getenv("POIESIS_IMAGE_PULL_POLICY", "IfNotPresent")


### PR DESCRIPTION
- Add validation in delete_pvc() to skip deletion when PVC name is empty
- Add safety check in TORC error handling to only delete PVC if name is valid
- Set BACKOFF_LIMIT=0 to prevent Kubernetes from automatically retrying failed jobs

#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #72 

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Prevent accidental mass PVC deletions by validating PVC names, simplify Torc execution by removing internal retry loops, and disable Kubernetes job retries by setting backoff limit to zero.

Bug Fixes:
- Skip PVC deletion when the provided name is empty or whitespace.
- Ensure error handling only deletes valid PVCs through the new name validation.

Enhancements:
- Remove the internal retry loop in Torc to streamline task execution and error propagation.

Deployment:
- Set BACKOFF_LIMIT to 0 to disable automatic Kubernetes job retries.