### PR TITLE
feat(filer): add fallbacks for non-compliant clients

### DIFF
--- a/deployment/helm/templates/minio/secret.yaml
+++ b/deployment/helm/templates/minio/secret.yaml
@@ -15,4 +15,5 @@ type: Opaque
 stringData:
   AWS_ACCESS_KEY_ID: {{ .Values.poiesis.externalDependencies.minio.auth.rootUser | quote }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.poiesis.externalDependencies.minio.auth.rootPassword | quote }}
-{{- end }}
+  AWS_REGION: {{ .Values.poiesis.externalDependencies.minio.region | quote }}
+  {{- end }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -203,6 +203,8 @@ poiesis:
       enabled: false
       # URL of the external Minio server (e.g., "http://minio.example.com:9000").
       url: ""
+      # Region of the external Minio server.
+      region: "Auto"
       # Auth configs
       auth:
         # Access key (username) for the external Minio instance.

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -11,7 +11,7 @@ fullnameOverride: ""
 
 # Common annotations to add to all resources created by this chart.
 # Useful for adding metadata like ownership, contact info, or integration points.
-commonAnnotations: {}
+commonAnnotations:
   # Example:
   # my-annotation: "my-value"
 
@@ -32,7 +32,7 @@ poiesis:
     # The Kubernetes image pull policy (e.g., Always, Never, IfNotPresent).
     pullPolicy: IfNotPresent
     # The tag of the Docker image to use (e.g., "latest", "v0.1.0"). "latest" is generally not recommended for production.
-    tag: "latest"
+    tag: "v0.1.0"
 
   # Configuration for the Kubernetes Service exposing the Poiesis application.
   service:
@@ -199,11 +199,12 @@ poiesis:
         password: "" # <-- IMPORTANT: Secure this value.
     # Configuration for connecting to an external Minio (S3-compatible) object storage instance.
     minio:
-      # If true, Poiesis will use the connection details specified below instead of deploying the minio sub-chart.
+      # If true, Poiesis will use the connection details specified.
       enabled: false
       # URL of the external Minio server (e.g., "http://minio.example.com:9000").
+      # This might not be needed for AWS S3.
       url: ""
-      # Region of the external Minio server.
+      # S3 region. This might not be needed for some S3 compatible object store.
       region: "Auto"
       # Auth configs
       auth:

--- a/docs/app/docs/deploy/deploying-poiesis.md
+++ b/docs/app/docs/deploy/deploying-poiesis.md
@@ -49,7 +49,7 @@ If not installed, install MongoDB, Redis, and MinIO via dev.yaml, we will use
 namespace for the Poiesis deployment.
 
 ```bash
-kubectl apply -f ../dev.yaml -n deps --create-namespace
+kubectl apply -f ../dev.yaml -n deps
 ```
 
 ## Install Poiesis
@@ -57,11 +57,11 @@ kubectl apply -f ../dev.yaml -n deps --create-namespace
 ```bash
 helm install poiesis . \
   -n poiesis --create-namespace \
-  --set externalDependencies.mongodb.connectionString="mongodb://admin:password@mongodb.deps.svc.cluster.local:27017/poiesis?authSource=admin" \
-  --set externalDependencies.redis.host="redis.deps.svc.cluster.local" \
-  --set externalDependencies.redis.port="6379" \
-  --set externalDependencies.redis.auth.enabled=true \
-  --set externalDependencies.redis.auth.password="password"
+  --set poiesis.externalDependencies.mongodb.connectionString="mongodb://admin:password@mongodb.deps.svc.cluster.local:27017/poiesis?authSource=admin" \
+  --set poiesis.externalDependencies.redis.host="redis.deps.svc.cluster.local" \
+  --set poiesis.externalDependencies.redis.port="6379" \
+  --set poiesis.externalDependencies.redis.auth.enabled=true \
+  --set poiesis.externalDependencies.redis.auth.password="password"
 ```
 
 :::warning change the above settings as needed
@@ -124,15 +124,15 @@ include MinIO.
 ```bash
 helm upgrade --install poiesis . \
   -n poiesis --create-namespace \
-  --set externalDependencies.mongodb.connectionString="mongodb://admin:password@mongodb.deps.svc.cluster.local:27017/poiesis?authSource=admin" \
-  --set externalDependencies.redis.host="redis.deps.svc.cluster.local" \
-  --set externalDependencies.redis.port="6379" \
-  --set externalDependencies.redis.auth.enabled=true \
-  --set externalDependencies.redis.auth.password="password" \
-  --set externalDependencies.minio.enabled=true \
-  --set externalDependencies.minio.url="http://minio.deps.svc.cluster.local:9000" \
-  --set externalDependencies.minio.auth.rootUser="admin" \
-  --set externalDependencies.minio.auth.rootPassword="password"
+  --set poiesis.externalDependencies.mongodb.connectionString="mongodb://admin:password@mongodb.deps.svc.cluster.local:27017/poiesis?authSource=admin" \
+  --set poiesis.externalDependencies.redis.host="redis.deps.svc.cluster.local" \
+  --set poiesis.externalDependencies.redis.port="6379" \
+  --set poiesis.externalDependencies.redis.auth.enabled=true \
+  --set poiesis.externalDependencies.redis.auth.password="password" \
+  --set poiesis.externalDependencies.minio.enabled=true \
+  --set poiesis.externalDependencies.minio.url="http://minio.deps.svc.cluster.local:9000" \
+  --set poiesis.externalDependencies.minio.auth.rootUser="admin" \
+  --set poiesis.externalDependencies.minio.auth.rootPassword="password"
 ```
 
 Now Poiesis will be configured with MinIO.
@@ -232,15 +232,15 @@ values (either in `values.yaml` or via `helm upgrade --set ...`):
 ```bash
 helm upgrade \
     -n poiesis --create-namespace \
-    --set externalDependencies.mongodb.connectionString="mongodb://admin:password@mongodb.deps.svc.cluster.local:27017/poiesis?authSource=admin" \
-    --set externalDependencies.redis.host="redis.deps.svc.cluster.local" \
-    --set externalDependencies.redis.port="6379" \
-    --set externalDependencies.redis.auth.enabled=true \
-    --set externalDependencies.redis.auth.password="password" \
-    --set externalDependencies.minio.enabled=true \
-    --set externalDependencies.minio.url="http://minio.deps.svc.cluster.local:9000" \
-    --set externalDependencies.minio.auth.rootUser="admin" \
-    --set externalDependencies.minio.auth.rootPassword="password" \
+    --set poiesis.externalDependencies.mongodb.connectionString="mongodb://admin:password@mongodb.deps.svc.cluster.local:27017/poiesis?authSource=admin" \
+    --set poiesis.externalDependencies.redis.host="redis.deps.svc.cluster.local" \
+    --set poiesis.externalDependencies.redis.port="6379" \
+    --set poiesis.externalDependencies.redis.auth.enabled=true \
+    --set poiesis.externalDependencies.redis.auth.password="password" \
+    --set poiesis.externalDependencies.minio.enabled=true \
+    --set poiesis.externalDependencies.minio.url="http://minio.deps.svc.cluster.local:9000" \
+    --set poiesis.externalDependencies.minio.auth.rootUser="admin" \
+    --set poiesis.externalDependencies.minio.auth.rootPassword="password" \
     --set poiesis.auth.type=oidc \
     --set poiesis.auth.oidc.issuer=http://keycloak.poiesis.svc.cluster.local/realms/poiesis \
     --set poiesis.auth.oidc.clientId=poiesis \

--- a/poiesis/core/constants.py
+++ b/poiesis/core/constants.py
@@ -283,6 +283,16 @@ def get_s3_envs() -> tuple[V1EnvVar, ...]:
                     )
                 ),
             ),
+            V1EnvVar(
+                name="AWS_REGION",
+                value_from=V1EnvVarSource(
+                    secret_key_ref=V1SecretKeySelector(
+                        name=core_constants.K8s.S3_SECRET_NAME,
+                        key="AWS_REGION",
+                        optional=True,
+                    )
+                ),
+            ),
         )
         if core_constants.K8s.S3_SECRET_NAME
         else ()

--- a/poiesis/core/services/filer/strategy/filer_strategy.py
+++ b/poiesis/core/services/filer/strategy/filer_strategy.py
@@ -240,11 +240,6 @@ class FilerStrategy(ABC):
             and os.path.exists(container_path)
             and os.path.isfile(container_path)
         ):
-            if not os.path.exists(container_path):
-                logger.error(
-                    f"Output file specified but not found at path: {container_path}. "
-                    "This may indicate a task failure.",
-                )
             await self.upload_output_file(container_path)
 
         # Handle standard directory uploads.

--- a/poiesis/core/services/filer/strategy/filer_strategy.py
+++ b/poiesis/core/services/filer/strategy/filer_strategy.py
@@ -181,10 +181,7 @@ class FilerStrategy(ABC):
         # Find the last directory separator before the pattern.
         last_slash_index = path.rfind("/", 0, pattern_start_index)
 
-        if last_slash_index == -1:
-            return "/"
-
-        return path[: last_slash_index + 1]
+        return "/" if last_slash_index == -1 else path[: last_slash_index + 1]
 
     async def upload(self):
         """Upload file to storage created by executors, mounted to PVC.
@@ -256,6 +253,6 @@ class FilerStrategy(ABC):
                 logger.warning(
                     "Output specified as file but not found at"
                     f"path: {container_path}. Assuming it to be"
-                    "a directory",
+                    "a directory.",
                 )
             await self.upload_output_directory(container_path)

--- a/poiesis/core/services/filer/strategy/filer_strategy.py
+++ b/poiesis/core/services/filer/strategy/filer_strategy.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 from abc import ABC, abstractmethod
 from glob import glob
 
@@ -153,15 +154,108 @@ class FilerStrategy(ABC):
 
         return _ret
 
+    def _path_contains_glob(self, path: str) -> bool:
+        """Checks if a path string contains glob-like characters."""
+        return any(char in path for char in "*?[]{}")
+
+    def _infer_base_path(self, path: str) -> str:
+        """Infers the base directory from a glob path.
+
+        This is used as the 'path_prefix' for calculating
+        relative upload paths. Fallback in case TES client
+        doesn't provide path_prefix but still has a glob pattern.
+
+        Example: '/work/results/SRR*.fna' -> '/work/results/'
+        """
+        if not self._path_contains_glob(path):
+            return os.path.dirname(path)
+
+        # Find the part of the path before the first wildcard.
+        glob_pattern = re.compile(r"[\*\?\[\{]")
+        match = glob_pattern.search(path)
+        if not match:
+            # Should be unreachable if _path_contains_glob is true, but defensive.
+            return os.path.dirname(path)
+
+        pattern_start_index = match.start()
+        # Find the last directory separator before the pattern.
+        last_slash_index = path.rfind("/", 0, pattern_start_index)
+
+        if last_slash_index == -1:
+            return "/"
+
+        return path[: last_slash_index + 1]
+
     async def upload(self):
         """Upload file to storage created by executors, mounted to PVC.
 
-        Get the appropriate secrets, check permissions and upload the file.
+        This method correctly dispatches to glob, file, or directory handlers
+        and includes robust logging and fallback mechanisms.
         """
+        assert isinstance(self.payload, TesOutput)
+        is_glob_like = self._path_contains_glob(self.payload.path)
         container_path = self._get_container_path(self.payload.path)
-        if isinstance(self.payload, TesOutput) and self.payload.path_prefix:
-            await self.upload_glob(self._get_glob_files(container_path))
-        elif self.payload.type == TesFileType.FILE:
+
+        # Handle all glob-related operations first.
+        if self.payload.path_prefix or is_glob_like:
+            # Ensure a path_prefix exists, inferring if necessary for
+            # non-compliant clients.
+            if is_glob_like and not self.payload.path_prefix:
+                inferred_prefix = self._infer_base_path(self.payload.path)
+                logger.debug(
+                    f"Inferred path_prefix '{inferred_prefix}' from "
+                    f"path '{self.payload.path}'",
+                )
+                self.payload.path_prefix = inferred_prefix
+
+            assert self.payload.path_prefix is not None, (
+                "path_prefix is required for glob operations but was not found "
+                "or inferred."
+            )
+
+            # Execute the glob and evaluate results.
+            globbed_files = self._get_glob_files(container_path)
+
+            if globbed_files:
+                logger.info(
+                    f"Found {len(globbed_files)} file(s) matching glob "
+                    f"pattern '{self.payload.path}'.",
+                )
+                logger.debug(
+                    "Glob matched files: %s", [item[0] for item in globbed_files]
+                )
+                await self.upload_glob(globbed_files)
+            else:
+                logger.warning(
+                    f"Output glob pattern '{self.payload.path}' did not match any "
+                    "files. Falling back to uploading the entire parent directory"
+                    f"'{self.payload.path_prefix}'. This may indicate a "
+                    "misconfiguration in the workflow definition.",
+                )
+                parent_dir_container_path = self._get_container_path(
+                    self.payload.path_prefix
+                )
+                await self.upload_output_directory(parent_dir_container_path)
+
+        # Handle standard file uploads.
+        elif (
+            self.payload.type == TesFileType.FILE
+            and os.path.exists(container_path)
+            and os.path.isfile(container_path)
+        ):
+            if not os.path.exists(container_path):
+                logger.error(
+                    f"Output file specified but not found at path: {container_path}. "
+                    "This may indicate a task failure.",
+                )
             await self.upload_output_file(container_path)
+
+        # Handle standard directory uploads.
         else:
+            if self.payload.type == TesFileType.FILE:
+                logger.warning(
+                    "Output specified as file but not found at"
+                    f"path: {container_path}. Assuming it to be"
+                    "a directory",
+                )
             await self.upload_output_directory(container_path)


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #79 
- Fixes #81 

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Enable AWS S3 support with region configuration, custom endpoint handling, and robust glob fallbacks in the S3 filer strategy with improved URL parsing and logging.

New Features:
- Support AWS S3 region configuration via AWS_REGION environment variable in Poiesis and Helm charts
- Allow specifying a custom S3 endpoint without a URL scheme and default to http with a warning

Enhancements:
- Introduce key sanitization for S3 glob patterns and infer base paths for file uploads
- Refactor upload logic to handle glob patterns first, infer missing path_prefix, and fallback to directory uploads when no matches
- Improve S3 URL parsing to more robustly extract host, bucket, and key components
- Standardize and enrich logging across S3 filer and upload strategy using f-strings

Deployment:
- Add AWS_REGION to the Minio Helm secret template and default values