### PR TITLE
feat(helm): add S3 backend, resource limits, and ingress/route support

### DIFF
--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   and cross-institutional research by standardizing task execution across different
   compute backends.
 
-version: 0.1.5
+version: 0.2.0
 appVersion: latest
 icon: https://raw.githubusercontent.com/JaeAeich/poiesis/refs/heads/main/docs/app/public/logo/logo.png
 

--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   and cross-institutional research by standardizing task execution across different
   compute backends.
 
-version: 0.1.0
+version: 0.1.5
 appVersion: latest
 icon: https://raw.githubusercontent.com/JaeAeich/poiesis/refs/heads/main/docs/app/public/logo/logo.png
 

--- a/deployment/helm/templates/_helper.tpl
+++ b/deployment/helm/templates/_helper.tpl
@@ -168,6 +168,17 @@ Redis Secret name
 {{- end }}
 
 
+{{/* ----------------------------- Validation ----------------------------- */}}
+
+{{/*
+Validate that minio and s3 are not both enabled
+*/}}
+{{- define "poiesis.validateStorageBackend" -}}
+{{- if and .Values.poiesis.externalDependencies.minio.enabled .Values.poiesis.externalDependencies.s3.enabled -}}
+{{- fail "Both minio and s3 cannot be enabled at the same time. Please enable only one storage backend." -}}
+{{- end -}}
+{{- end -}}
+
 {{/* -----------------------------  S3/Minio ----------------------------- */}}
 
 {{/*

--- a/deployment/helm/templates/minio/secret.yaml
+++ b/deployment/helm/templates/minio/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.poiesis.externalDependencies.minio.enabled }}
+{{- if and (.Values.poiesis.externalDependencies.minio.enabled) (not .Values.poiesis.externalDependencies.s3.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,4 +16,24 @@ stringData:
   AWS_ACCESS_KEY_ID: {{ .Values.poiesis.externalDependencies.minio.auth.rootUser | quote }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.poiesis.externalDependencies.minio.auth.rootPassword | quote }}
   AWS_REGION: {{ .Values.poiesis.externalDependencies.minio.region | quote }}
+{{- end }}
+
+{{- if and (.Values.poiesis.externalDependencies.s3.enabled) (not .Values.poiesis.externalDependencies.minio.enabled) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "poiesis.s3.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "poiesis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: s3
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: {{ .Values.poiesis.externalDependencies.s3.auth.accessKey | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.poiesis.externalDependencies.s3.auth.secretKey | quote }}
+  AWS_REGION: {{ .Values.poiesis.externalDependencies.s3.region | quote }}
+{{- end }}

--- a/deployment/helm/templates/poiesis/configmap.yaml
+++ b/deployment/helm/templates/poiesis/configmap.yaml
@@ -25,7 +25,12 @@ data:
   {{- if .Values.poiesis.externalDependencies.redis.auth.enabled }}
   POIESIS_REDIS_SECRET_NAME: {{ include "poiesis.redis.secretName" . }}
   {{- end }}
-  {{- if .Values.poiesis.externalDependencies.minio.enabled }}
+  {{- if and (.Values.poiesis.externalDependencies.minio.enabled) (not .Values.poiesis.externalDependencies.s3.enabled) }}
   S3_URL: {{ .Values.poiesis.externalDependencies.minio.url | quote }}
   POIESIS_S3_SECRET_NAME: {{include "poiesis.s3.secretName" . }}
+  {{- else if and (.Values.poiesis.externalDependencies.s3.enabled) (not .Values.poiesis.externalDependencies.minio.enabled) }}
+  S3_URL: {{ .Values.poiesis.externalDependencies.s3.endpoint | quote }}
+  POIESIS_S3_SECRET_NAME: {{include "poiesis.s3.secretName" . }}
+  AWS_REQUEST_CHECKSUM_CALCULATION: {{ .Values.poiesis.externalDependencies.s3.awsRequest.checksumCalculation | quote }}
+  AWS_REQUEST_CHECKSUM_VALIDATION: {{ .Values.poiesis.externalDependencies.s3.awsRequest.checksumValidation | quote }}
   {{- end }}

--- a/deployment/helm/templates/poiesis/configmap.yaml
+++ b/deployment/helm/templates/poiesis/configmap.yaml
@@ -25,12 +25,12 @@ data:
   {{- if .Values.poiesis.externalDependencies.redis.auth.enabled }}
   POIESIS_REDIS_SECRET_NAME: {{ include "poiesis.redis.secretName" . }}
   {{- end }}
-  {{- if and (.Values.poiesis.externalDependencies.minio.enabled) (not .Values.poiesis.externalDependencies.s3.enabled) }}
+  {{- if .Values.poiesis.externalDependencies.minio.enabled }}
   S3_URL: {{ .Values.poiesis.externalDependencies.minio.url | quote }}
-  POIESIS_S3_SECRET_NAME: {{include "poiesis.s3.secretName" . }}
-  {{- else if and (.Values.poiesis.externalDependencies.s3.enabled) (not .Values.poiesis.externalDependencies.minio.enabled) }}
+  POIESIS_S3_SECRET_NAME: {{ include "poiesis.s3.secretName" . }}
+  {{- else if .Values.poiesis.externalDependencies.s3.enabled }}
   S3_URL: {{ .Values.poiesis.externalDependencies.s3.endpoint | quote }}
-  POIESIS_S3_SECRET_NAME: {{include "poiesis.s3.secretName" . }}
+  POIESIS_S3_SECRET_NAME: {{ include "poiesis.s3.secretName" . }}
   AWS_REQUEST_CHECKSUM_CALCULATION: {{ .Values.poiesis.externalDependencies.s3.awsRequest.checksumCalculation | quote }}
   AWS_REQUEST_CHECKSUM_VALIDATION: {{ .Values.poiesis.externalDependencies.s3.awsRequest.checksumValidation | quote }}
   {{- end }}

--- a/deployment/helm/templates/poiesis/deployment.yaml
+++ b/deployment/helm/templates/poiesis/deployment.yaml
@@ -139,7 +139,9 @@ spec:
                   name: {{ include "poiesis.coreConfigMapName" . }}
                   key: POIESIS_S3_SECRET_NAME
             {{- end }}
-          resources: {{- toYaml .Values.poiesis.resources | nindent 12 }}
+          {{- with .Values.poiesis.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if or .Values.poiesis.securityContext.infrastructure.enabled .Values.poiesis.securityContext.executors.enabled }}
           volumeMounts:
             - name: {{ include "poiesis.securityConfigMapName" . }}

--- a/deployment/helm/templates/poiesis/deployment.yaml
+++ b/deployment/helm/templates/poiesis/deployment.yaml
@@ -132,13 +132,14 @@ spec:
                   name: {{ include "poiesis.auth.secretName" . }}
                   key: OIDC_CLIENT_SECRET
             {{- end }}
-            {{- if .Values.poiesis.externalDependencies.minio.enabled }}
+            {{- if or (.Values.poiesis.externalDependencies.minio.enabled) (.Values.poiesis.externalDependencies.s3.enabled) }}
             - name: POIESIS_S3_SECRET_NAME
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "poiesis.coreConfigMapName" . }}
                   key: POIESIS_S3_SECRET_NAME
             {{- end }}
+          resources: {{- toYaml .Values.poiesis.resources | nindent 12 }}
           {{- if or .Values.poiesis.securityContext.infrastructure.enabled .Values.poiesis.securityContext.executors.enabled }}
           volumeMounts:
             - name: {{ include "poiesis.securityConfigMapName" . }}

--- a/deployment/helm/templates/poiesis/ingress.yaml
+++ b/deployment/helm/templates/poiesis/ingress.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.poiesis.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "poiesis.fullname" . }}-ingress
+  labels:
+    {{- include "poiesis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.poiesis.ingress.tls.enabled }}
+  tls:
+    - hosts:
+      - {{ .Values.poiesis.ingress.hostname | quote }}
+      secretName: {{ .Values.poiesis.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.poiesis.ingress.hostname | quote }}
+      http:
+        paths:
+          - path: {{ .Values.poiesis.ingress.path }}
+            pathType: {{ .Values.poiesis.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "poiesis.api.componentName" . }}
+                port:
+                  number: {{ .Values.poiesis.service.port }}
+{{- end }}
+
+{{- if and (.Capabilities.APIVersions.Has "route.openshift.io/v1") (eq .Values.poiesis.ingress.enabled false) }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "poiesis.fullname" . }}-route
+  labels:
+    {{- include "poiesis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  host: {{ .Values.poiesis.ingress.hostname | quote }}
+  port:
+    targetPort: {{ .Values.poiesis.service.port }}
+  tls:
+    insecureEdgeTerminationPolicy: {{ .Values.poiesis.ingress.tls.insecureEdgeTerminationPolicy }}
+    termination: {{ .Values.poiesis.ingress.tls.termination }}
+  to:
+    kind: Service
+    name: {{ include "poiesis.api.componentName" . }}
+    weight: 100
+  wildcardPolicy: None
+{{- end }}

--- a/deployment/helm/templates/poiesis/ingress.yaml
+++ b/deployment/helm/templates/poiesis/ingress.yaml
@@ -6,15 +6,20 @@ metadata:
   labels:
     {{- include "poiesis.labels" . | nindent 4 }}
     app.kubernetes.io/component: api
-  {{- with .Values.commonAnnotations }}
+  {{- if or .Values.poiesis.ingress.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.poiesis.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   {{- if .Values.poiesis.ingress.tls.enabled }}
   tls:
     - hosts:
-      - {{ .Values.poiesis.ingress.hostname | quote }}
+        - {{ .Values.poiesis.ingress.hostname | quote }}
       secretName: {{ .Values.poiesis.ingress.tls.secretName }}
   {{- end }}
   rules:
@@ -30,7 +35,8 @@ spec:
                   number: {{ .Values.poiesis.service.port }}
 {{- end }}
 
-{{- if and (.Capabilities.APIVersions.Has "route.openshift.io/v1") (eq .Values.poiesis.ingress.enabled false) }}
+{{- if and (.Capabilities.APIVersions.Has "route.openshift.io/v1") .Values.poiesis.route.enabled }}
+---
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -43,12 +49,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  host: {{ .Values.poiesis.ingress.hostname | quote }}
+  host: {{ .Values.poiesis.route.hostname | default .Values.poiesis.ingress.hostname | quote }}
   port:
     targetPort: {{ .Values.poiesis.service.port }}
   tls:
-    insecureEdgeTerminationPolicy: {{ .Values.poiesis.ingress.tls.insecureEdgeTerminationPolicy }}
-    termination: {{ .Values.poiesis.ingress.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.poiesis.route.tls.insecureEdgeTerminationPolicy }}
+    termination: {{ .Values.poiesis.route.tls.termination }}
   to:
     kind: Service
     name: {{ include "poiesis.api.componentName" . }}

--- a/deployment/helm/templates/s3/secret.yaml
+++ b/deployment/helm/templates/s3/secret.yaml
@@ -1,5 +1,5 @@
 {{- include "poiesis.validateStorageBackend" . -}}
-{{- if .Values.poiesis.externalDependencies.minio.enabled }}
+{{- if .Values.poiesis.externalDependencies.s3.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,14 +7,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "poiesis.labels" . | nindent 4 }}
-    app.kubernetes.io/component: minio
+    app.kubernetes.io/component: s3
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque
 stringData:
-  AWS_ACCESS_KEY_ID: {{ .Values.poiesis.externalDependencies.minio.auth.rootUser | quote }}
-  AWS_SECRET_ACCESS_KEY: {{ .Values.poiesis.externalDependencies.minio.auth.rootPassword | quote }}
-  AWS_REGION: {{ .Values.poiesis.externalDependencies.minio.region | quote }}
+  AWS_ACCESS_KEY_ID: {{ .Values.poiesis.externalDependencies.s3.auth.accessKey | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.poiesis.externalDependencies.s3.auth.secretKey | quote }}
+  AWS_REGION: {{ .Values.poiesis.externalDependencies.s3.region | quote }}
 {{- end }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -21,19 +21,28 @@ poiesis:
   # Controls whether the Poiesis application itself is deployed.
   # Note: Useful during development, disable poiesis but enable all its components
   #   expose them and run hot loaded poiesis.
-  #   If deployed on OpenShift and ingress.enabled is false, then route will be created instead of ingress.
+  #   For OpenShift deployments, enable route separately via poiesis.route.enabled.
   enabled: true
   ingress:
     enabled: false
     hostname: "poiesis.example.com"
+    # Ingress-specific annotations (e.g., nginx.ingress.kubernetes.io/rewrite-target: /)
+    annotations: {}
     tls:
       enabled: false
       secretName: ""
-      # For route configuration
-      insecureEdgeTerminationPolicy: Redirect
-      termination: edge
     path: /
     pathType: Prefix
+
+  # OpenShift Route configuration.
+  # Only created when the cluster supports route.openshift.io/v1.
+  route:
+    enabled: false
+    # Hostname for the route. Falls back to ingress.hostname if not set.
+    hostname: ""
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
 
   # Specifies the number of Poiesis application pods to run.
   replicaCount: 1
@@ -52,17 +61,17 @@ poiesis:
     # The type of Kubernetes Service (e.g., ClusterIP, NodePort, LoadBalancer).
     type: ClusterIP
     # The port on which the Service will expose the Poiesis application within the cluster.
-    port: "8000" # Corresponds to the target port on the Poiesis container.
+    port: 8000 # Corresponds to the target port on the Poiesis container.
 
   # Configuration for resource requests and limits for the Poiesis API pod.
   resources:
     # Resource requests and limits for the Poiesis API pod.
     # Adjust these values based on your cluster's capacity and application needs.
     requests:
-      memory: "2Gi"
+      memory: "512Mi"
       cpu: "250m"
     limits:
-      memory: "2Gi"
+      memory: "1Gi"
       cpu: "500m"
 
   # Poiesis application-specific runtime configuration.

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -21,7 +21,20 @@ poiesis:
   # Controls whether the Poiesis application itself is deployed.
   # Note: Useful during development, disable poiesis but enable all its components
   #   expose them and run hot loaded poiesis.
+  #   If deployed on OpenShift and ingress.enabled is false, then route will be created instead of ingress.
   enabled: true
+  ingress:
+    enabled: false
+    hostname: ""
+    tls:
+      enabled: false
+      secretName: ""
+      # For route configuration
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    path: /
+    pathType: Prefix
+
   # Specifies the number of Poiesis application pods to run.
   replicaCount: 1
 
@@ -40,6 +53,17 @@ poiesis:
     type: ClusterIP
     # The port on which the Service will expose the Poiesis application within the cluster.
     port: "8000" # Corresponds to the target port on the Poiesis container.
+
+  # Configuration for resource requests and limits for the Poiesis API pod.
+  resources:
+    # Resource requests and limits for the Poiesis API pod.
+    # Adjust these values based on your cluster's capacity and application needs.
+    requests:
+      memory: "2Gi"
+      cpu: "250m"
+    limits:
+      memory: "2Gi"
+      cpu: "500m"
 
   # Poiesis application-specific runtime configuration.
   # These values are typically passed as environment variables or configuration files to the application.
@@ -212,3 +236,20 @@ poiesis:
         rootUser: ""
         # Secret key (password) for the external Minio instance. Use secrets management for production.
         rootPassword: "" # <-- IMPORTANT: Secure this value.
+    s3:
+      # If true, Poiesis will use the connection details specified.
+      enabled: false
+      # URL of the external S3 server (e.g., "https://s3.amazonaws.com").
+      endpoint: ""
+      # S3 region. This might not be needed for some S3 compatible object store.
+      region: ""
+      awsRequest:
+        # AWS request checksum calculation setting. Options: "NEVER", "WHEN_REQUIRED", "ALWAYS".
+        checksumCalculation: "WHEN_REQUIRED"
+        # AWS request checksum validation setting. Options: "NEVER", "WHEN_REQUIRED", "ALWAYS".
+        checksumValidation: "WHEN_REQUIRED"
+      auth:
+        # Access key (username) for the external S3 instance.
+        accessKey: ""
+        # Secret key (password) for the external S3 instance. Use secrets management for production.
+        secretKey: "" # <-- IMPORTANT: Secure this value.

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -25,7 +25,7 @@ poiesis:
   enabled: true
   ingress:
     enabled: false
-    hostname: ""
+    hostname: "poiesis.example.com"
     tls:
       enabled: false
       secretName: ""

--- a/poiesis/core/constants.py
+++ b/poiesis/core/constants.py
@@ -293,6 +293,26 @@ def get_s3_envs() -> tuple[V1EnvVar, ...]:
                     )
                 ),
             ),
+            V1EnvVar(
+                name="AWS_REQUEST_CHECKSUM_CALCULATION",
+                value_from=V1EnvVarSource(
+                    config_map_key_ref=V1ConfigMapKeySelector(
+                        name=core_constants.K8s.CONFIGMAP_NAME,
+                        key="AWS_REQUEST_CHECKSUM_CALCULATION",
+                        optional=True,
+                    )
+                ),
+            ),
+            V1EnvVar(
+                name="AWS_REQUEST_CHECKSUM_VALIDATION",
+                value_from=V1EnvVarSource(
+                    config_map_key_ref=V1ConfigMapKeySelector(
+                        name=core_constants.K8s.CONFIGMAP_NAME,
+                        key="AWS_REQUEST_CHECKSUM_VALIDATION",
+                        optional=True,
+                    )
+                ),
+            ),
         )
         if core_constants.K8s.S3_SECRET_NAME
         else ()


### PR DESCRIPTION
#### Description

- Add s3 values
  - Edit secret.yaml
  - Edit configmap.yaml
  - Add Checksum env
- Add resources for the deployment
- Add Ingress/Route

## Summary by Sourcery

Update the Helm chart to support configurable external S3 backends, resource limits, and Kubernetes/OpenShift ingress exposure for the Poiesis API.

New Features:
- Add configurable ingress settings and ingress/route templates to expose the Poiesis API via Kubernetes Ingress or OpenShift Route.
- Introduce optional external S3 configuration distinct from Minio, including dedicated secrets and checksum-related settings.
- Define configurable CPU and memory requests/limits for the Poiesis deployment via Helm values.

Enhancements:
- Adjust Minio-related configmap, secrets, and deployment wiring to coexist with or defer to the new generic S3 configuration.
- Bump the Helm chart version to reflect the extended configuration surface.